### PR TITLE
M1: Implement quantizer core with scale/pitch utilities and spectral …

### DIFF
--- a/docs/MilestoneNotes/M1-quantizer-core.md
+++ b/docs/MilestoneNotes/M1-quantizer-core.md
@@ -1,0 +1,119 @@
+# Milestone M1: Quantizer Core
+
+## Summary
+
+This milestone implements the core spectral pitch quantization functionality for the Quantum Distortion project. The quantizer module provides utilities for converting frequencies to musical scales, building target bins for frequency quantization, and applying spectral quantization to FFT frames. The pipeline has been updated to expose quantizer parameters in preparation for full integration in future milestones.
+
+## Prompts Executed
+
+### PROMPT 1.1 — Create quantizer.py with scale + pitch utilities
+- Created `quantum_distortion/dsp/quantizer.py` with comprehensive pitch quantization functionality
+- Implemented scale definitions:
+  - Major, minor, pentatonic, dorian, mixolydian, harmonic_minor scales
+  - Scale intervals defined as pitch class offsets from root
+- Implemented harmonic weight system:
+  - Root (1.0), Fifth (0.8), Third (0.7), Seventh (0.6), Other (0.5)
+  - Used to prioritize certain scale degrees during quantization
+- Core functions:
+  - `note_name_to_pitch_class()` - Converts note names (C, C#, Db, etc.) to pitch class 0-11
+  - `midi_to_freq()` / `freq_to_midi()` - Frequency/MIDI conversion utilities
+  - `build_scale_notes()` - Generates scale notes across octaves for a given frequency range
+  - `build_target_bins_for_freqs()` - Maps frequency bins to nearest in-scale target bins
+  - `quantize_spectrum()` - Applies spectral quantization to FFT frames with configurable snap strength, smear, and bin smoothing
+- Added Python 3.7 compatibility by using `typing_extensions` for `Literal` type
+- All functions use `.copy()` to avoid mutating input arrays
+
+### PROMPT 1.2 — Add unit tests for quantizer behavior
+- Created `tests/test_quantizer.py` with comprehensive unit tests
+- Test coverage:
+  - `test_build_target_bins_simple_monotonic()` - Validates target bin mapping for frequencies near scale notes
+  - `test_quantize_moves_energy_to_target_bin()` - Verifies energy moves from off-scale bins to nearest in-scale bin with snap_strength=1.0
+  - `test_quantize_smear_distributes_energy()` - Validates that smearing redistributes energy around target bins
+  - `test_bin_smoothing_changes_shape_not_energy()` - Ensures bin smoothing changes shape while preserving total energy
+- All tests use small synthetic spectra (not real FFTs) for fast, deterministic testing
+- Tests validate core quantization behavior: energy movement, smear distribution, and energy conservation
+
+### PROMPT 1.3 — Wire quantizer into pipeline stub
+- Updated `process_audio()` in `quantum_distortion/dsp/pipeline.py`:
+  - Added comprehensive docstring explaining Milestone 1 status
+  - Added mono audio validation (raises ValueError for non-1D arrays)
+  - Added `distortion_params` initialization if None
+  - All quantizer parameters already exposed in function signature (key, scale, snap_strength, smear, bin_smoothing, pre_quant, post_quant)
+  - Still operates as pass-through (quantization not yet applied, preparing for Milestone 2/3)
+- Fixed Python 3.7 compatibility in `quantum_distortion/io/audio_io.py`:
+  - Replaced `|` union syntax with `Union` from typing module
+  - Updated `load_audio()` and `save_audio()` function signatures
+- Maintained backward compatibility with CLI script and existing tests
+
+### PROMPT 1.4 — Quick regression run
+- Verified all tests pass:
+  - `tests/test_imports_and_io.py::test_roundtrip` - PASSED
+  - All 4 tests in `tests/test_quantizer.py` - PASSED
+- Confirmed no import errors from `quantum_distortion.dsp.quantizer`
+- Total: 5 tests passed in 0.47 seconds
+
+## Files Created/Modified
+
+### New Files
+- `quantum_distortion/dsp/quantizer.py` - Core quantizer module with scale/pitch utilities and spectral quantization
+- `tests/test_quantizer.py` - Comprehensive unit tests for quantizer functionality
+
+### Modified Files
+- `quantum_distortion/dsp/pipeline.py` - Updated `process_audio()` with quantizer parameter exposure, mono validation, and docstring
+- `quantum_distortion/io/audio_io.py` - Fixed Python 3.7 compatibility (replaced `|` union syntax with `Union`)
+
+## Key Features Implemented
+
+### Scale and Pitch Utilities
+- Support for 6 musical scales: major, minor, pentatonic, dorian, mixolydian, harmonic_minor
+- Note name parsing with sharp/flat support (normalized to sharps)
+- MIDI to frequency conversion and vice versa
+- Scale note generation across multiple octaves for any frequency range
+
+### Spectral Quantization
+- Target bin computation based on weighted distance to in-scale notes
+- Configurable snap strength (0.0 = no movement, 1.0 = full attraction)
+- Energy smearing with Gaussian-like distribution around target bins
+- Optional bin smoothing with moving-average kernel
+- Energy conservation: total magnitude preserved during quantization
+
+### Harmonic Weighting
+- Root notes have highest weight (1.0)
+- Fifths, thirds, sevenths have progressively lower weights
+- Other scale degrees have lowest weight (0.5)
+- Weights influence which scale notes attract off-scale frequencies
+
+## Technical Details
+
+### Python Compatibility
+- Added Python 3.7 support by using `typing_extensions` for `Literal` type
+- Replaced Python 3.10+ union syntax (`|`) with `Union` from typing module
+- All code tested on Python 3.7.4
+
+### Code Quality
+- All functions use `.copy()` to avoid mutating input arrays
+- Comprehensive type hints throughout
+- Docstrings for all public functions
+- No circular imports (quantizer only imports standard library and numpy)
+
+### Testing
+- Fast unit tests using synthetic spectra (no external file dependencies)
+- Tests validate energy conservation, shape changes, and quantization behavior
+- All tests pass consistently
+
+## Verification
+
+- ✅ All tests pass (5/5)
+- ✅ No import errors
+- ✅ Backward compatible with CLI script
+- ✅ No linting errors
+- ✅ Python 3.7 compatible
+
+## Next Steps
+
+The quantizer core is complete and ready for:
+1. Integration with STFT processing in Milestone 2
+2. Application of quantization in the audio pipeline
+3. Real-time processing optimizations
+4. UI visualization of quantization effects
+

--- a/quantum_distortion/dsp/pipeline.py
+++ b/quantum_distortion/dsp/pipeline.py
@@ -1,67 +1,56 @@
 import numpy as np
 
-from typing import Any, Dict, Tuple
-
+from typing import Any, Dict, Tuple, Union
 
 
 from quantum_distortion.config import (
-
-    DEFAULT_KEY, DEFAULT_SCALE,
-
-    DEFAULT_SNAP_STRENGTH, DEFAULT_SMEAR,
-
-    DEFAULT_BIN_SMOOTHING, DEFAULT_DISTORTION_MODE,
-
-    DEFAULT_LIMITER_ON, DEFAULT_LIMITER_CEILING_DB,
-
-    DEFAULT_DRY_WET, DEFAULT_SAMPLE_RATE
-
+    DEFAULT_KEY,
+    DEFAULT_SCALE,
+    DEFAULT_SNAP_STRENGTH,
+    DEFAULT_SMEAR,
+    DEFAULT_BIN_SMOOTHING,
+    DEFAULT_DISTORTION_MODE,
+    DEFAULT_LIMITER_ON,
+    DEFAULT_LIMITER_CEILING_DB,
+    DEFAULT_DRY_WET,
+    DEFAULT_SAMPLE_RATE,
 )
 
 
-
 def process_audio(
-
     audio: np.ndarray,
-
     sr: int = DEFAULT_SAMPLE_RATE,
-
     key: str = DEFAULT_KEY,
-
     scale: str = DEFAULT_SCALE,
-
     snap_strength: float = DEFAULT_SNAP_STRENGTH,
-
     smear: float = DEFAULT_SMEAR,
-
     bin_smoothing: bool = DEFAULT_BIN_SMOOTHING,
-
     pre_quant: bool = True,
-
     post_quant: bool = True,
-
     distortion_mode: str = DEFAULT_DISTORTION_MODE,
-
-    distortion_params: Dict[str, Any] | None = None,
-
+    distortion_params: Union[Dict[str, Any], None] = None,
     limiter_on: bool = DEFAULT_LIMITER_ON,
-
     limiter_ceiling_db: float = DEFAULT_LIMITER_CEILING_DB,
-
     dry_wet: float = DEFAULT_DRY_WET,
-
 ) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
+    """
+    Main offline processing entry point.
+
+    Milestone 1:
+    - API exposes quantizer-related parameters but does not yet apply them.
+    - Audio is still passed through unchanged.
+    """
+    if distortion_params is None:
+        distortion_params = {}
+
+    if audio.ndim != 1:
+        # For now, enforce mono for MVP core DSP; stereo support can be added later.
+        raise ValueError("process_audio currently expects mono audio (1D array)")
 
     taps = {
-
         "input": audio.copy(),
-
         "pre_quant": audio.copy(),
-
         "post_dist": audio.copy(),
-
         "output": audio.copy(),
-
     }
-
     return audio.copy(), taps

--- a/quantum_distortion/dsp/quantizer.py
+++ b/quantum_distortion/dsp/quantizer.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+
+from dataclasses import dataclass
+
+from typing import Dict, Tuple
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+
+import numpy as np
+
+
+ScaleName = Literal["major", "minor", "pentatonic", "dorian", "mixolydian", "harmonic_minor"]
+
+
+NOTE_NAMES_SHARP = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+
+SCALE_INTERVALS: Dict[ScaleName, Tuple[int, ...]] = {
+    "major": (0, 2, 4, 5, 7, 9, 11),
+    "minor": (0, 2, 3, 5, 7, 8, 10),
+    "pentatonic": (0, 2, 4, 7, 9),
+    "dorian": (0, 2, 3, 5, 7, 9, 10),
+    "mixolydian": (0, 2, 4, 5, 7, 9, 10),
+    "harmonic_minor": (0, 2, 3, 5, 7, 8, 11),
+}
+
+
+HARMONIC_WEIGHTS: Dict[str, float] = {
+    "root": 1.0,
+    "fifth": 0.8,
+    "third": 0.7,
+    "seventh": 0.6,
+    "other": 0.5,
+}
+
+
+@dataclass(frozen=True)
+class ScaleNote:
+    midi: int
+    freq: float
+    role: str  # "root", "fifth", "third", "seventh", "other"
+    weight: float
+
+
+def note_name_to_pitch_class(name: str) -> int:
+    """
+    Convert note name like "C", "C#", "Db", "A", "Bb" to pitch class 0-11.
+
+    Supports sharps (#) and flats (b); flats are normalized to sharps.
+    """
+    name = name.strip().upper()
+    name = name.replace("DB", "C#").replace("EB", "D#").replace("GB", "F#").replace("AB", "G#").replace("BB", "A#")
+    if name not in NOTE_NAMES_SHARP:
+        raise ValueError(f"Unsupported key name: {name}")
+    return NOTE_NAMES_SHARP.index(name)
+
+
+def midi_to_freq(midi: float) -> float:
+    return 440.0 * (2.0 ** ((midi - 69.0) / 12.0))
+
+
+def freq_to_midi(freq: float) -> float:
+    if freq <= 0.0:
+        return -np.inf
+    return 69.0 + 12.0 * np.log2(freq / 440.0)
+
+
+def _classify_role(pitch_class: int, root_pc: int) -> str:
+    """
+    Classify a scale degree role relative to the root.
+    """
+    interval = (pitch_class - root_pc) % 12
+    if interval == 0:
+        return "root"
+    if interval == 7:
+        return "fifth"
+    if interval in (3, 4):
+        return "third"
+    if interval in (10, 11):
+        return "seventh"
+    return "other"
+
+
+def build_scale_notes(
+    key: str,
+    scale: ScaleName,
+    min_freq: float,
+    max_freq: float,
+) -> list[ScaleNote]:
+    """
+    Build a list of scale notes (across octaves) that span [min_freq, max_freq].
+    """
+    root_pc = note_name_to_pitch_class(key)
+    intervals = SCALE_INTERVALS[scale]
+
+    # Choose a broad MIDI range so we cover audio band
+    min_midi = int(np.floor(freq_to_midi(max(min_freq, 20.0)))) - 12
+    max_midi = int(np.ceil(freq_to_midi(min(max_freq, 22050.0)))) + 12
+
+    notes: list[ScaleNote] = []
+    for midi in range(min_midi, max_midi + 1):
+        pitch_class = midi % 12
+        if (pitch_class - root_pc) % 12 in intervals:
+            freq = midi_to_freq(float(midi))
+            if freq < min_freq * 0.5 or freq > max_freq * 2.0:
+                continue
+            role = _classify_role(pitch_class, root_pc)
+            weight = HARMONIC_WEIGHTS[role]
+            notes.append(ScaleNote(midi=midi, freq=freq, role=role, weight=weight))
+    return notes
+
+
+def build_target_bins_for_freqs(
+    freqs: np.ndarray,
+    key: str,
+    scale: ScaleName,
+) -> np.ndarray:
+    """
+    For each frequency bin, compute the target bin index it should be attracted to,
+    based on nearest in-scale note and harmonic weighting.
+
+
+    Returns
+    -------
+    target_bins: np.ndarray[int] of shape (len(freqs),)
+    """
+    freqs = np.asarray(freqs, dtype=float)
+    if freqs.ndim != 1:
+        raise ValueError("freqs must be 1D array")
+
+    valid = np.isfinite(freqs) & (freqs > 0.0)
+    if not np.any(valid):
+        return np.arange(len(freqs), dtype=int)
+
+    min_freq = float(np.min(freqs[valid]))
+    max_freq = float(np.max(freqs[valid]))
+    scale_notes = build_scale_notes(key, scale, min_freq, max_freq)
+
+    if not scale_notes:
+        # Fallback: identity mapping
+        return np.arange(len(freqs), dtype=int)
+
+    note_freqs = np.array([n.freq for n in scale_notes], dtype=float)
+    note_weights = np.array([n.weight for n in scale_notes], dtype=float)
+
+    # Avoid division by zero
+    note_weights = np.clip(note_weights, 1e-3, None)
+
+    target_bins = np.arange(len(freqs), dtype=int)
+
+    for i, f in enumerate(freqs):
+        if not valid[i]:
+            continue
+
+        # Weighted distance: smaller is better
+        df = np.abs(note_freqs - f)
+        # cost ~ distance / weight (root/fifths more attractive)
+        cost = df / note_weights
+        idx = int(np.argmin(cost))
+        target_freq = note_freqs[idx]
+
+        # Find nearest FFT bin to target_freq
+        bin_idx = int(np.argmin(np.abs(freqs - target_freq)))
+        target_bins[i] = bin_idx
+
+    return target_bins
+
+
+def quantize_spectrum(
+    mags: np.ndarray,
+    phases: np.ndarray,
+    freqs: np.ndarray,
+    key: str,
+    scale: ScaleName,
+    snap_strength: float,
+    smear: float,
+    bin_smoothing: bool,
+    smear_radius: int = 2,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Apply spectral quantization to a single FFT frame.
+
+
+    Parameters
+    ----------
+    mags : np.ndarray
+        Magnitude spectrum (1D).
+    phases : np.ndarray
+        Phase spectrum (1D), same shape as mags.
+    freqs : np.ndarray
+        Frequency per bin (1D).
+    key : str
+        Musical key (e.g. "C", "D#", "A", "Bb").
+    scale : ScaleName
+        Scale name (e.g. "major", "minor").
+    snap_strength : float
+        0.0 → no movement, 1.0 → full attraction to target bins.
+    smear : float
+        0.0 → all moved energy goes to target bin,
+        1.0 → all moved energy is smeared around target within smear_radius.
+    bin_smoothing : bool
+        If True, apply simple moving-average smoothing to magnitudes after quantization.
+    smear_radius : int
+        Number of bins on each side of target bin to smear into.
+
+
+    Returns
+    -------
+    new_mags, new_phases
+    """
+    mags = np.asarray(mags, dtype=float)
+    phases = np.asarray(phases, dtype=float)
+    freqs = np.asarray(freqs, dtype=float)
+
+    if mags.shape != phases.shape or mags.shape != freqs.shape:
+        raise ValueError("mags, phases, and freqs must have the same shape")
+
+    if mags.ndim != 1:
+        raise ValueError("quantize_spectrum expects 1D arrays")
+
+    snap_strength = float(np.clip(snap_strength, 0.0, 1.0))
+    smear = float(np.clip(smear, 0.0, 1.0))
+
+    # Early out: no snapping, no smoothing
+    if snap_strength <= 0.0 and not bin_smoothing:
+        return mags.copy(), phases.copy()
+
+    target_bins = build_target_bins_for_freqs(freqs, key, scale)
+
+    new_mags = mags.copy()
+
+    # Move energy toward targets
+    for i in range(len(mags)):
+        mag = mags[i]
+        if mag <= 0.0:
+            continue
+
+        target_bin = target_bins[i]
+        if target_bin < 0 or target_bin >= len(mags):
+            continue
+
+        energy_to_move = mag * snap_strength
+        if energy_to_move <= 0.0:
+            continue
+
+        # Remove from source
+        new_mags[i] -= energy_to_move
+
+        # Split into direct target + smeared neighbors
+        base_energy = energy_to_move * (1.0 - smear)
+        smear_energy = energy_to_move * smear
+
+        # Direct target
+        new_mags[target_bin] += base_energy
+
+        if smear_energy > 0.0 and smear_radius > 0:
+            # Simple Gaussian-like kernel over [target-r, target+r]
+            indices = np.arange(
+                max(0, target_bin - smear_radius),
+                min(len(mags), target_bin + smear_radius + 1),
+                dtype=int,
+            )
+            distances = np.abs(indices - target_bin).astype(float)
+            # Gaussian-ish weights (center highest)
+            sigma = max(1.0, smear_radius / 2.0)
+            weights = np.exp(-0.5 * (distances / sigma) ** 2)
+            weights_sum = np.sum(weights)
+            if weights_sum > 0:
+                weights /= weights_sum
+                new_mags[indices] += smear_energy * weights
+
+    # Optional bin smoothing
+    if bin_smoothing and len(new_mags) > 2:
+        kernel = np.array([0.25, 0.5, 0.25], dtype=float)
+        # 'same' convolution
+        padded = np.pad(new_mags, (1, 1), mode="edge")
+        smoothed = np.convolve(padded, kernel, mode="same")[1:-1]
+        new_mags = smoothed
+
+    # Phases remain unchanged in MVP
+    return new_mags, phases.copy()
+

--- a/quantum_distortion/io/audio_io.py
+++ b/quantum_distortion/io/audio_io.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from typing import Tuple
+from typing import Tuple, Union, Optional
 
 import numpy as np
 
@@ -8,7 +8,7 @@ import soundfile as sf
 
 
 
-def load_audio(path: str | Path, target_sr: int | None = None) -> Tuple[np.ndarray, int]:
+def load_audio(path: Union[str, Path], target_sr: Optional[int] = None) -> Tuple[np.ndarray, int]:
 
     path = Path(path)
 
@@ -18,7 +18,7 @@ def load_audio(path: str | Path, target_sr: int | None = None) -> Tuple[np.ndarr
 
 
 
-def save_audio(path: str | Path, audio: np.ndarray, sr: int) -> None:
+def save_audio(path: Union[str, Path], audio: np.ndarray, sr: int) -> None:
 
     path = Path(path)
 

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -1,0 +1,108 @@
+import numpy as np
+
+
+from quantum_distortion.dsp.quantizer import (
+    quantize_spectrum,
+    build_target_bins_for_freqs,
+)
+
+
+def test_build_target_bins_simple_monotonic() -> None:
+    # Frequencies in Hz: DC, off-scale, near A root
+    freqs = np.array([0.0, 430.0, 440.0, 450.0], dtype=float)
+
+    # Key A minor: A (440Hz) should be a strong attractor
+    target_bins = build_target_bins_for_freqs(freqs, key="A", scale="minor")
+
+    # DC bin maps to itself
+    assert target_bins[0] == 0
+
+    # 430 & 450 should both be attracted near 440 bin (index 2)
+    assert target_bins[1] == 2
+    assert target_bins[2] == 2
+    assert target_bins[3] == 2
+
+
+def test_quantize_moves_energy_to_target_bin() -> None:
+    # 4-bin synthetic spectrum
+    freqs = np.array([0.0, 430.0, 440.0, 450.0], dtype=float)
+    mags = np.array([0.0, 1.0, 0.0, 0.0], dtype=float)
+    phases = np.zeros_like(mags)
+
+    new_mags, new_phases = quantize_spectrum(
+        mags=mags,
+        phases=phases,
+        freqs=freqs,
+        key="A",
+        scale="minor",
+        snap_strength=1.0,
+        smear=0.0,
+        bin_smoothing=False,
+    )
+
+    # All energy should move from bin 1 → bin 2 (target)
+    assert np.isclose(new_mags[1], 0.0, atol=1e-6)
+    assert np.isclose(new_mags[2], 1.0, atol=1e-6)
+    assert np.isclose(np.sum(new_mags), np.sum(mags), atol=1e-6)
+
+    # Phases unchanged
+    assert np.allclose(new_phases, phases)
+
+
+def test_quantize_smear_distributes_energy() -> None:
+    freqs = np.array([0.0, 430.0, 440.0, 450.0], dtype=float)
+    mags = np.array([0.0, 1.0, 0.0, 0.0], dtype=float)
+    phases = np.zeros_like(mags)
+
+    new_mags, _ = quantize_spectrum(
+        mags=mags,
+        phases=phases,
+        freqs=freqs,
+        key="A",
+        scale="minor",
+        snap_strength=1.0,
+        smear=0.8,  # most energy smeared around target
+        bin_smoothing=False,
+        smear_radius=1,
+    )
+
+    # Source bin (1) has energy removed but may receive smeared energy back
+    # since it's within smear_radius of target (2)
+    # The key is that energy is distributed across multiple bins
+    assert new_mags[1] < 0.5  # Less than original, but may have smeared energy
+
+    # Neighbor bins around target (1,2,3) should all have some energy
+    assert new_mags[1] > 0.0
+    assert new_mags[2] > 0.0
+    assert new_mags[3] > 0.0
+    
+    # Target bin should have the most energy (direct + smeared)
+    assert new_mags[2] > new_mags[1]
+    assert new_mags[2] > new_mags[3]
+
+    # Total magnitude approximately conserved
+    assert np.isclose(np.sum(new_mags), np.sum(mags), atol=1e-4)
+
+
+def test_bin_smoothing_changes_shape_not_energy() -> None:
+    freqs = np.array([100.0, 200.0, 300.0, 400.0], dtype=float)
+    mags = np.array([0.0, 0.0, 1.0, 0.0], dtype=float)
+    phases = np.zeros_like(mags)
+
+    new_mags, _ = quantize_spectrum(
+        mags=mags,
+        phases=phases,
+        freqs=freqs,
+        key="C",
+        scale="major",
+        snap_strength=0.0,    # no movement
+        smear=0.0,
+        bin_smoothing=True,   # only smoothing
+    )
+
+    # Shape must change (central peak spreads)
+    assert not np.allclose(new_mags, mags)
+
+    # Energy should be approximately conserved
+    assert np.isclose(np.sum(new_mags), np.sum(mags), atol=1e-6)
+


### PR DESCRIPTION
M1: Implement quantizer core with scale/pitch utilities and spectral quantization

- Created quantizer.py with comprehensive pitch quantization functionality
  * Support for 6 musical scales (major, minor, pentatonic, dorian, mixolydian, harmonic_minor)
  * Harmonic weighting system (root, fifth, third, seventh, other)
  * Frequency/MIDI conversion utilities
  * Scale note generation across octaves
  * Target bin computation for frequency quantization
  * Spectral quantization with configurable snap strength, smear, and bin smoothing

- Added comprehensive unit tests (test_quantizer.py)
  * Tests for target bin mapping
  * Tests for energy movement to target bins
  * Tests for smear distribution
  * Tests for bin smoothing energy conservation
  * All tests use synthetic spectra for fast, deterministic testing

- Updated pipeline.py to expose quantizer parameters
  * Added mono audio validation
  * Added comprehensive docstring
  * Maintains backward compatibility with CLI script
  * Still operates as pass-through (quantization integration in M2/M3)

- Fixed Python 3.7 compatibility
  * Replaced | union syntax with Union from typing
  * Added typing_extensions fallback for Literal type

- Created milestone documentation (M1-quantizer-core.md)
  * Detailed summary of all changes
  * Documentation of features and technical details

All tests pass (5/5). No import errors. Ready for STFT integration in M2.