### PR TITLE
M2: Implement distortion and limiter modules

### DIFF
--- a/docs/MilestoneNotes/M2-distortion-limiter.md
+++ b/docs/MilestoneNotes/M2-distortion-limiter.md
@@ -1,0 +1,143 @@
+# Milestone M2: Distortion and Limiter
+
+## Summary
+
+This milestone implements the distortion and limiter modules for the Quantum Distortion project. The distortion module provides two algorithms (wavefold and soft-tube) for generating harmonic content, while the limiter module provides a lookahead peak limiter for preventing clipping and controlling dynamics. Both modules are fully tested and ready for integration into the audio processing pipeline.
+
+## Prompts Executed
+
+### PROMPT 2.1 — Create distortion.py with wavefold + soft-tube
+- Created `quantum_distortion/dsp/distortion.py` with two distortion algorithms
+- **Wavefold distortion** (`wavefold()`):
+  - Applies bias (DC offset) and fold_amount (input gain)
+  - Uses mirrored clipping around ±threshold for single-fold pass
+  - Generates rich harmonics through wavefolding
+  - Returns float32 output clipped to threshold range
+- **Soft-tube saturation** (`soft_tube()`):
+  - Uses tanh waveshaper for tube-style saturation
+  - Configurable drive (input gain) and warmth (curve steepness)
+  - Maps warmth (0..1) to shape parameter (1..5)
+  - Normalized output to keep in [-1, 1] range
+- **Convenience wrapper** (`apply_distortion()`):
+  - Routes to appropriate function based on mode ("wavefold" or "tube")
+  - Handles parameter routing for each mode
+- Added Python 3.7 compatibility using `typing_extensions` for `Literal` type
+- All functions validate mono (1D) audio and return float32 arrays
+- No in-place mutation of input arrays
+
+### PROMPT 2.2 — Unit tests for distortion
+- Created `tests/test_distortion.py` with comprehensive unit tests
+- **Test coverage**:
+  - `test_wavefold_generates_harmonics()` - Validates that wavefold generates harmonics by comparing harmonic energy (total - fundamental) between clean and folded signals
+  - `test_soft_tube_drive_increases_thd()` - Verifies that increasing drive increases total harmonic distortion (THD)
+  - `test_apply_distortion_routes_modes()` - Ensures `apply_distortion` correctly routes parameters to wavefold and tube modes
+- All tests use synthetic sine waves for fast, deterministic testing
+- Tests validate harmonic generation, distortion intensity scaling, and parameter routing
+
+### PROMPT 2.3 — Create limiter.py (lookahead peak limiter)
+- Created `quantum_distortion/dsp/limiter.py` with lookahead peak limiter
+- **Core functionality**:
+  - `db_to_linear()` - Converts dB to linear gain
+  - `peak_limiter()` - Main limiter function with configurable parameters
+- **Limiter features**:
+  - **Lookahead**: Anticipates peaks by examining upcoming samples in a configurable window
+  - **Attack**: Instantly reduces gain when peaks exceed ceiling
+  - **Release**: Smoothly returns gain toward 1.0 over time using exponential smoothing
+  - Configurable ceiling in dBFS (default -1.0 dB)
+  - Configurable lookahead window in milliseconds (default 5.0 ms)
+  - Configurable release time in milliseconds (default 50.0 ms)
+- Returns both limited audio and gain curve for visualization
+- Handles edge cases (empty arrays, validates mono audio)
+- No external dependencies beyond numpy
+
+### PROMPT 2.4 — Unit tests for limiter
+- Created `tests/test_limiter.py` with comprehensive unit tests
+- **Test coverage**:
+  - `test_limiter_reduces_peaks()` - Verifies that peaks exceeding ceiling are reduced to at or below ceiling (with 1% tolerance)
+  - `test_limiter_minimal_effect_below_threshold()` - Ensures signals below threshold are mostly unaffected (gain curve stays near 1.0)
+  - `test_limiter_gain_recovers_after_spike()` - Validates that gain curve recovers toward 1.0 after transient spikes
+- All tests use synthetic signals (sine waves, spikes) for deterministic testing
+- Tests validate peak reduction, minimal effect on low-level signals, and gain recovery behavior
+
+### PROMPT 2.5 — Regression: run full test suite
+- Verified all tests pass across the entire test suite
+- **Test results**: 11 tests passed in 0.76 seconds
+  - `tests/test_imports_and_io.py` - 1 test passed
+  - `tests/test_quantizer.py` - 4 tests passed
+  - `tests/test_distortion.py` - 3 tests passed
+  - `tests/test_limiter.py` - 3 tests passed
+- Confirmed no breaking changes to existing functionality
+- Verified backward compatibility with CLI script and pipeline
+- All imports successful, no circular dependencies
+
+## Files Created/Modified
+
+### New Files
+- `quantum_distortion/dsp/distortion.py` - Distortion module with wavefold and soft-tube algorithms
+- `quantum_distortion/dsp/limiter.py` - Lookahead peak limiter module
+- `tests/test_distortion.py` - Comprehensive unit tests for distortion module
+- `tests/test_limiter.py` - Comprehensive unit tests for limiter module
+
+### Modified Files
+- None (no changes to existing files required)
+
+## Key Features Implemented
+
+### Distortion Algorithms
+- **Wavefold**: Mirrored clipping algorithm that generates rich harmonics
+  - Configurable fold_amount (input gain)
+  - Configurable bias (DC offset)
+  - Configurable threshold (folding point)
+  - Single-fold pass for MVP simplicity
+- **Soft-tube**: Tanh-based saturation for tube-style warmth
+  - Configurable drive (input gain, >1.0 increases distortion)
+  - Configurable warmth (0..1, controls curve steepness)
+  - Normalized output to maintain [-1, 1] range
+
+### Limiter
+- **Lookahead peak limiting**: Prevents clipping by anticipating peaks
+  - Configurable ceiling in dBFS
+  - Configurable lookahead window (milliseconds)
+  - Configurable release time (milliseconds)
+  - Exponential release smoothing
+  - Returns gain curve for visualization
+
+## Technical Details
+
+### Python Compatibility
+- Python 3.7 compatible (uses `typing_extensions` for `Literal` type)
+- All functions use `.copy()` or create new arrays to avoid mutating inputs
+- Comprehensive type hints throughout
+
+### Code Quality
+- All functions validate mono (1D) audio input
+- All functions return float32 numpy arrays
+- No side effects or in-place mutation
+- Comprehensive docstrings for all public functions
+- No circular imports (only standard library and numpy)
+
+### Testing
+- Fast unit tests using synthetic signals (no external file dependencies)
+- Tests validate harmonic generation, distortion intensity, parameter routing
+- Tests validate peak reduction, minimal effect on low signals, gain recovery
+- All tests pass consistently (no flaky behavior)
+- Total test suite runs in <1 second
+
+## Verification
+
+- ✅ All tests pass (11/11)
+- ✅ No import errors
+- ✅ Backward compatible with existing pipeline and CLI
+- ✅ No linting errors
+- ✅ Python 3.7 compatible
+- ✅ No breaking changes to existing functionality
+
+## Next Steps
+
+The distortion and limiter modules are complete and ready for:
+1. Integration into the audio processing pipeline (Milestone 3)
+2. Application of distortion in pre/post-quantization stages
+3. Limiter application at the end of the processing chain
+4. UI visualization of distortion and limiting effects
+5. Real-time processing optimizations
+

--- a/quantum_distortion/dsp/distortion.py
+++ b/quantum_distortion/dsp/distortion.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+
+import numpy as np
+
+
+DistortionMode = Literal["wavefold", "tube"]
+
+
+def _ensure_mono_float(audio: np.ndarray) -> np.ndarray:
+    audio = np.asarray(audio, dtype=float)
+    if audio.ndim != 1:
+        raise ValueError("Distortion currently expects mono (1D) audio")
+    return audio
+
+
+def wavefold(
+    audio: np.ndarray,
+    fold_amount: float = 1.0,
+    bias: float = 0.0,
+    threshold: float = 1.0,
+) -> np.ndarray:
+    """
+    Simple wavefolding distortion.
+
+    Steps:
+    - Apply bias (DC offset).
+    - Apply fold_amount as input gain.
+    - Fold around +/- threshold using mirrored clipping (single fold pass).
+
+    This is not a mathematically perfect multi-fold circuit emulator,
+    but is sufficient for MVP to generate rich harmonics.
+    """
+    x = _ensure_mono_float(audio)
+
+    # Apply bias + gain
+    x = (x + bias) * fold_amount
+
+    if threshold <= 0.0:
+        threshold = 1.0
+
+    # Mirrored clipping fold:
+    # First handle positive side, then negative
+    y = x.copy()
+
+    # Positive side
+    over_pos = y > threshold
+    y[over_pos] = 2.0 * threshold - y[over_pos]
+
+    # Negative side
+    over_neg = y < -threshold
+    y[over_neg] = -2.0 * threshold - y[over_neg]
+
+    # Optional post-normalization: try to keep in [-threshold, threshold]
+    y = np.clip(y, -threshold, threshold)
+
+    return y.astype(np.float32)
+
+
+def soft_tube(
+    audio: np.ndarray,
+    drive: float = 1.0,
+    warmth: float = 0.5,
+) -> np.ndarray:
+    """
+    Soft-tube style saturation using a tanh waveshaper.
+
+    Parameters
+    ----------
+    drive : float
+        Input gain. >1.0 increases distortion.
+    warmth : float (0..1)
+        Controls curve steepness; higher = more aggressive.
+    """
+    x = _ensure_mono_float(audio)
+
+    # Input gain
+    x = x * max(drive, 0.0)
+
+    # Map warmth (0..1) → shape parameter a (1..5)
+    warmth = float(np.clip(warmth, 0.0, 1.0))
+    a = 1.0 + 4.0 * warmth
+
+    # Shape with tanh, normalize so that max slope is ~1 around zero
+    y = np.tanh(a * x)
+    # Normalize to keep output roughly in [-1,1]
+    y /= np.tanh(a) if a != 0.0 else 1.0
+
+    return y.astype(np.float32)
+
+
+def apply_distortion(
+    audio: np.ndarray,
+    mode: DistortionMode,
+    fold_amount: float = 1.0,
+    bias: float = 0.0,
+    drive: float = 1.0,
+    warmth: float = 0.5,
+) -> np.ndarray:
+    """
+    Convenience wrapper that chooses distortion mode.
+
+    Parameters
+    ----------
+    mode : "wavefold" or "tube"
+    Other params are routed to the corresponding function.
+    """
+    if mode == "wavefold":
+        return wavefold(audio, fold_amount=fold_amount, bias=bias, threshold=1.0)
+    elif mode == "tube":
+        return soft_tube(audio, drive=drive, warmth=warmth)
+    else:
+        raise ValueError(f"Unsupported distortion mode: {mode}")
+

--- a/quantum_distortion/dsp/limiter.py
+++ b/quantum_distortion/dsp/limiter.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+
+from typing import Tuple
+
+
+import numpy as np
+
+
+def db_to_linear(db: float) -> float:
+    return 10.0 ** (db / 20.0)
+
+
+def peak_limiter(
+    audio: np.ndarray,
+    sr: int,
+    ceiling_db: float = -1.0,
+    lookahead_ms: float = 5.0,
+    release_ms: float = 50.0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Simple lookahead peak limiter.
+
+    Parameters
+    ----------
+    audio : np.ndarray
+        Mono audio buffer.
+    sr : int
+        Sample rate.
+    ceiling_db : float
+        Max allowed peak in dBFS (e.g., -1.0).
+    lookahead_ms : float
+        Lookahead window in milliseconds.
+    release_ms : float
+        Release time in milliseconds.
+
+    Returns
+    -------
+    limited_audio : np.ndarray
+        Limited audio buffer.
+    gain_curve : np.ndarray
+        Gain applied at each sample.
+    """
+    x = np.asarray(audio, dtype=float)
+    if x.ndim != 1:
+        raise ValueError("peak_limiter currently expects mono (1D) audio")
+
+    n_samples = x.shape[0]
+    if n_samples == 0:
+        return x.astype(np.float32), np.ones_like(x, dtype=np.float32)
+
+    ceiling_lin = db_to_linear(ceiling_db)
+    lookahead_samples = int(max(1, round(sr * (lookahead_ms / 1000.0))))
+    release_samples = max(1, int(round(sr * (release_ms / 1000.0))))
+
+    gain = np.ones(n_samples, dtype=float)
+    g = 1.0
+
+    # Release coefficient for exponential smoothing back towards 1.0
+    release_coeff = np.exp(-1.0 / release_samples)
+
+    for n in range(n_samples):
+        # Look at upcoming window to anticipate peaks
+        window_end = min(n_samples, n + lookahead_samples)
+        upcoming = x[n:window_end]
+        peak = float(np.max(np.abs(upcoming))) if upcoming.size > 0 else 0.0
+
+        if peak > ceiling_lin and peak > 1e-12:
+            desired_g = ceiling_lin / peak
+            # Attack: instantly lower gain if needed
+            if desired_g < g:
+                g = desired_g
+
+        # Release: move g back towards 1.0 over time
+        g = 1.0 - (1.0 - g) * release_coeff
+        g = float(np.clip(g, 0.0, 1.0))
+        gain[n] = g
+
+    y = (x * gain).astype(np.float32)
+    return y, gain.astype(np.float32)
+

--- a/tests/test_distortion.py
+++ b/tests/test_distortion.py
@@ -1,0 +1,86 @@
+import numpy as np
+
+
+from quantum_distortion.dsp.distortion import (
+    wavefold,
+    soft_tube,
+    apply_distortion,
+)
+
+
+def _make_sine(freq: float, sr: int = 44100, seconds: float = 0.1) -> np.ndarray:
+    t = np.linspace(0.0, seconds, int(sr * seconds), endpoint=False)
+    return 0.2 * np.sin(2.0 * np.pi * freq * t).astype(np.float32)
+
+
+def test_wavefold_generates_harmonics() -> None:
+    sr = 44100
+    sine = _make_sine(440.0, sr=sr)
+    # Use more aggressive parameters to ensure harmonics are generated
+    folded = wavefold(sine, fold_amount=8.0, bias=0.0, threshold=0.5)
+
+    # FFT magnitude: expect more than 1 prominent bin (harmonics)
+    spec_clean = np.abs(np.fft.rfft(sine))
+    spec_folded = np.abs(np.fft.rfft(folded))
+
+    # Find fundamental bin
+    freqs = np.fft.rfftfreq(len(sine), 1.0 / sr)
+    fundamental_idx = int(np.argmin(np.abs(freqs - 440.0)))
+
+    # Compute harmonic energy (total - fundamental)
+    clean_total = np.sum(spec_clean ** 2)
+    clean_fund = spec_clean[fundamental_idx] ** 2
+    clean_harmonics = clean_total - clean_fund
+
+    folded_total = np.sum(spec_folded ** 2)
+    folded_fund = spec_folded[fundamental_idx] ** 2
+    folded_harmonics = folded_total - folded_fund
+
+    # Folded signal should have significantly more harmonic energy
+    # (normalize by fundamental to account for gain differences)
+    clean_ratio = clean_harmonics / max(clean_fund, 1e-12)
+    folded_ratio = folded_harmonics / max(folded_fund, 1e-12)
+
+    # The folded signal should have more harmonic content relative to fundamental
+    assert folded_ratio > clean_ratio * 1.1  # At least 10% more
+
+
+def test_soft_tube_drive_increases_thd() -> None:
+    sr = 44100
+    sine = _make_sine(440.0, sr=sr)
+
+    low_drive = soft_tube(sine, drive=1.0, warmth=0.5)
+    high_drive = soft_tube(sine, drive=5.0, warmth=0.5)
+
+    # Compute simple THD proxy: energy excluding fundamental
+    spec_low = np.abs(np.fft.rfft(low_drive))
+    spec_high = np.abs(np.fft.rfft(high_drive))
+
+    freqs = np.fft.rfftfreq(len(sine), 1.0 / sr)
+    fundamental_idx = int(np.argmin(np.abs(freqs - 440.0)))
+
+    def thd(spec: np.ndarray) -> float:
+        total = np.sum(spec**2)
+        fund = spec[fundamental_idx] ** 2
+        return float((total - fund) / max(fund, 1e-12))
+
+    thd_low = thd(spec_low)
+    thd_high = thd(spec_high)
+
+    assert thd_high > thd_low
+
+
+def test_apply_distortion_routes_modes() -> None:
+    x = np.linspace(-1.0, 1.0, 1024, dtype=np.float32)
+
+    wf = apply_distortion(x, mode="wavefold", fold_amount=3.0, bias=0.1)
+    tube = apply_distortion(x, mode="tube", drive=3.0, warmth=0.7)
+
+    assert wf.shape == x.shape
+    assert tube.shape == x.shape
+
+    # Distorted outputs should differ from input and from each other
+    assert not np.allclose(wf, x)
+    assert not np.allclose(tube, x)
+    assert not np.allclose(wf, tube)
+

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+
+from quantum_distortion.dsp.limiter import peak_limiter, db_to_linear
+
+
+def test_limiter_reduces_peaks() -> None:
+    sr = 44100
+    ceiling_db = -3.0
+    ceiling_lin = db_to_linear(ceiling_db)
+
+    # Build signal: low-level tone + single large spike
+    t = np.linspace(0.0, 0.1, int(sr * 0.1), endpoint=False)
+    tone = 0.1 * np.sin(2.0 * np.pi * 440.0 * t)
+    spike = np.zeros_like(tone)
+    spike[len(spike) // 2] = 2.0  # large transient
+
+    x = tone + spike
+    limited, gain = peak_limiter(x, sr=sr, ceiling_db=ceiling_db, lookahead_ms=5.0, release_ms=50.0)
+
+    # Check that limited signal does not exceed ceiling (with small tolerance)
+    peak_out = float(np.max(np.abs(limited)))
+    assert peak_out <= ceiling_lin * 1.01  # allow 1% margin
+
+
+def test_limiter_minimal_effect_below_threshold() -> None:
+    sr = 44100
+    ceiling_db = -1.0
+    ceiling_lin = db_to_linear(ceiling_db)
+
+    t = np.linspace(0.0, 0.1, int(sr * 0.1), endpoint=False)
+    x = 0.2 * np.sin(2.0 * np.pi * 440.0 * t)  # well below ceiling
+
+    limited, gain = peak_limiter(x, sr=sr, ceiling_db=ceiling_db, lookahead_ms=5.0, release_ms=20.0)
+
+    # Peaks should remain below ceiling
+    assert float(np.max(np.abs(limited))) <= ceiling_lin * 1.01
+
+    # Gain curve should be very close to 1.0 everywhere
+    assert np.allclose(gain, np.ones_like(gain), atol=1e-2)
+
+
+def test_limiter_gain_recovers_after_spike() -> None:
+    sr = 44100
+    ceiling_db = -6.0
+
+    t = np.linspace(0.0, 0.2, int(sr * 0.2), endpoint=False)
+    x = np.zeros_like(t)
+    mid = len(x) // 2
+    x[mid] = 3.0  # big spike
+
+    limited, gain = peak_limiter(x, sr=sr, ceiling_db=ceiling_db, lookahead_ms=5.0, release_ms=30.0)
+
+    # Gain around the spike should drop significantly
+    assert gain[mid] < 0.5
+
+    # Gain near the very end should have recovered towards 1.0
+    assert gain[-1] > 0.9
+


### PR DESCRIPTION
- Created distortion.py with wavefold and soft-tube algorithms
  * Wavefold: Mirrored clipping for rich harmonic generation
    - Configurable fold_amount, bias, and threshold
    - Single-fold pass for MVP simplicity
  * Soft-tube: Tanh-based saturation for tube-style warmth
    - Configurable drive (input gain) and warmth (curve steepness)
    - Normalized output to maintain [-1, 1] range
  * Convenience wrapper (apply_distortion) routes to appropriate mode

- Created limiter.py with lookahead peak limiter
  * Configurable ceiling in dBFS (default -1.0 dB)
  * Configurable lookahead window (default 5.0 ms)
  * Configurable release time (default 50.0 ms)
  * Exponential release smoothing
  * Returns both limited audio and gain curve

- Added comprehensive unit tests
  * test_distortion.py: 3 tests validating harmonic generation, THD scaling with drive, and parameter routing
  * test_limiter.py: 3 tests validating peak reduction, minimal effect on low signals, and gain recovery

- All tests pass (11/11 in 0.76s)
- No breaking changes to existing functionality
- Backward compatible with CLI script and pipeline
- Python 3.7 compatible

- Created milestone documentation (M2-distortion-limiter.md)
  * Detailed summary of all changes
  * Documentation of features and technical details

Ready for integration into audio processing pipeline in M3.