### PR TITLE
Electron-first polyphonic retune redesign

### DIFF
--- a/docs/polyphonic-retune-redesign.md
+++ b/docs/polyphonic-retune-redesign.md
@@ -1,0 +1,157 @@
+# Electron-First Polyphonic Retune Redesign
+
+## Goal
+
+Make the Electron app the persistent product UI and replace the current split Python/JS pitch logic with one unified interactive backend that can grow into Pitchmap-style polyphonic note manipulation.
+
+This document is intentionally opinionated:
+
+- `spectral_bins` stays only as a creative spectral effect, not the correction core.
+- the current worklet retuner is treated as a realtime prototype, not the long-term engine.
+- the future backend is driven by the Electron UI contract first.
+
+## Product Scope
+
+### In Scope
+
+- interactive Electron-first workflow
+- polyphonic note-aware remapping
+- explicit note-target control
+- low-end handling that does not rely on a fixed sub oscillator as the source of truth
+- live engine telemetry in the UI
+
+### Out of Scope
+
+- preserving the current CLI as a product surface
+- presenting the current monophonic worklet as the final DSP design
+- treating FFT-bin attraction as autotune
+
+## Unified Architecture
+
+Target runtime layout:
+
+1. Electron/React UI
+2. unified backend host
+3. shared retune engine
+4. realtime status channel back to the UI
+
+The UI should never infer backend state from knob positions alone. The backend must report:
+
+- detected note groups
+- target note groups
+- confidence / lock state
+- low-end assignment strategy
+- engine mode
+- latency / CPU health
+
+## Backend Stages
+
+### Stage 1: Analysis Front End
+
+Use a polyphonic analysis front end instead of YIN:
+
+- constant-Q or log-frequency analysis for note-space stability
+- transient detection to protect attacks from smearing
+- harmonic/percussive separation or residual split
+- multi-pitch candidate extraction per frame
+- continuity tracking across frames so notes are stable objects, not isolated peaks
+
+Outputs:
+
+- note candidates with pitch, strength, bandwidth, and harmonic support
+- residual/unassigned energy
+- low-frequency note candidates
+
+### Stage 2: Note Assignment / Mapping
+
+Each tracked source note should be assignable to:
+
+- nearest in-key note
+- explicit user note map
+- chord or interval map
+- mute / preserve / collapse behaviors
+
+This is where Pitchmap-like behavior starts. The engine needs note objects, not one global pitch ratio.
+
+### Stage 3: Resynthesis
+
+Resynthesis should be note-group aware:
+
+- phase-consistent partial remapping for tonal components
+- transient bypass or protected transient lane
+- residual lane for noisy content
+- optional texture coloration after retune, not baked into it
+
+## Low-End Strategy
+
+The current fixed-note synthetic sub is acceptable as an effect, but it cannot be the corrective low-end strategy.
+
+Recommended low-end design:
+
+1. Split low end into three lanes:
+   - transient low-frequency energy
+   - stable tonal low-frequency note groups
+   - residual low-frequency noise
+2. Track low notes separately with a long-window log-frequency estimator or harmonic template matcher.
+3. Rebuild the tonal low end from assigned note groups:
+   - phase-locked sinusoidal bank
+   - oscillator-bank reinforcement tied to tracked source notes
+   - optional hybrid of shifted original low mids plus resynthesized fundamental
+4. Use the old fixed-note sub oscillator only as an optional reinforcement module.
+
+This keeps low-end note identity tied to the mapped note groups instead of a static root tone.
+
+## UI Contract
+
+The Electron UI should drive a backend contract shaped like this:
+
+- `engineMode`
+- `mappingMode`
+- `lowEndStrategy`
+- `preserveTransients`
+- `retuneStrength`
+- `textureAmount`
+- `subReinforcement`
+- `noteMap`
+- `status`
+
+The UI should receive:
+
+- active source notes
+- assigned target notes
+- confidence per note
+- low-end lock state
+- backend label
+- latency / overload flags
+
+## Migration Plan
+
+### Phase 0
+
+- keep the current worklet alive as the realtime prototype
+- expose live retune telemetry in the Electron UI
+- remove or fix misleading UI behaviors so the frontend matches the current singleton backend
+
+### Phase 1
+
+- define the shared backend contract around note groups and status reporting
+- move away from separate Python/JS product behaviors
+- make the Electron UI the only primary control surface
+
+### Phase 2
+
+- replace the monophonic detector with a polyphonic analysis front end
+- add note-group tracking and mapping
+- keep the current distortion / delay / modulation stages downstream of retune
+
+### Phase 3
+
+- replace the body-band delay-line pitch shifter with note-aware resynthesis
+- redesign low-end handling around tracked note groups
+- relegate the synthetic sub to an explicit reinforcement module
+
+## Immediate Code Implications
+
+- the current worklet status channel should be treated as the long-term UI telemetry path
+- module visibility/removal in the Electron UI must match actual backend behavior
+- the UI should stop implying that the current backend is already a true polyphonic mapper

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "electron:dev": "concurrently \"vite\" \"wait-on http://localhost:5173 && electron .\"",
     "electron:build": "vite build && electron-builder",
     "lint": "eslint .",
+    "test:retune-core": "node --test tests/retune-core.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/ui/public/worklets/quantum-processor.js
+++ b/ui/public/worklets/quantum-processor.js
@@ -1,17 +1,9 @@
-/**
- * Quantum Distortion - Realtime AudioWorklet Processor
- *
- * Runs in the audio thread. Implements:
- * - Wavefold distortion
- * - Soft-tube saturation (two independent stages)
- * - Body-band pitch quantization with detector filtering and generated sub
- * - Bitcrush / Lo-Fi
- * - Simple delay + feedback
- * - Chorus modulation
- * - 5-band parametric EQ with multiple filter types
- */
+import {
+  DEFAULT_RETUNE_PARAMS,
+  PolyphonicRetuneCore,
+  normalizeRetuneParamPatch,
+} from './retune-core.js';
 
-// Musical scale intervals (semitones from root)
 const SCALES = {
   major: [0, 2, 4, 5, 7, 9, 11],
   minor: [0, 2, 3, 5, 7, 8, 10],
@@ -22,69 +14,46 @@ const SCALES = {
   chromatic: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
 };
 
-const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-
 const MAX_CHANNELS = 2;
+const TWO_PI = Math.PI * 2;
 
 class QuantumProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
 
-    // Parameters controlled via message port
     this.params = {
-      // Global
       bypass: false,
       dryWet: 1.0,
       masterGain: 1.0,
 
-      // Saturation (stage 1)
       saturateEnabled: true,
-      saturateType: 'tape',     // tape, tube, wavefold
+      saturateType: 'tape',
       saturateDrive: 0.5,
       saturateTilt: 0.5,
 
-      // Saturation (stage 2)
       saturate2Enabled: true,
       saturate2Type: 'tape',
       saturate2Drive: 0.5,
       saturate2Tilt: 0.5,
 
-      // Spectral Quantize
-      quantizeEnabled: false,
-      quantizeKey: 0,           // 0=C, 1=C#, etc.
-      quantizeScale: 'major',
-      quantizeStrength: 0.7,
-      quantizeSubEnabled: true,
-      quantizeSubSource: 'root',
-      quantizeSubNote: 0,
-      quantizeSubDegree: 0,
-      quantizeSubOctave: 2,
-      quantizeSubLevel: 0.35,
-      quantizeAirMix: 1.0,
+      ...DEFAULT_RETUNE_PARAMS,
 
-      // Low/High end gains (applied post-chain)
       lowGain: 1.0,
       highGain: 1.0,
-
-      // Dev-only: drive range scaler (0-1, controls saturation intensity ceiling)
       _devDriveRange: 0.4,
 
-      // Delay
       delayEnabled: false,
-      delayTime: 0.25,          // seconds
+      delayTime: 0.25,
       delayFeedback: 0.3,
 
-      // Modulation (chorus)
       modEnabled: false,
       modDepth: 0.5,
-      modRate: 1.0,             // Hz
+      modRate: 1.0,
 
-      // Lo-Fi
       lofiEnabled: false,
       lofiWear: 0.5,
       lofiWobble: 0.3,
 
-      // EQ bands (5-band parametric with filter type)
       eqEnabled: true,
       eqBands: [
         { freq: 60, gain: 0, q: 1.0, type: 'lowshelf' },
@@ -93,24 +62,15 @@ class QuantumProcessor extends AudioWorkletProcessor {
         { freq: 4000, gain: 0, q: 1.0, type: 'peak' },
         { freq: 12000, gain: 0, q: 1.0, type: 'highshelf' },
       ],
-
-      // Key-aware parametric EQ instances
       peqInstances: [],
     };
 
-    // Per-channel state for stereo processing
-    // Delay buffers (max 2 seconds at 48kHz)
     this.delayBuffers = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(96000));
     this.delayWriteIndexes = new Array(MAX_CHANNELS).fill(0);
-
-    // Chorus LFO phase (shared across channels)
     this.chorusPhase = 0;
-
-    // Lo-Fi sample-and-hold state (per-channel)
     this.lofiHoldSamples = new Array(MAX_CHANNELS).fill(0);
     this.lofiHoldCounters = new Array(MAX_CHANNELS).fill(0);
 
-    // Biquad filter states for EQ (per-channel, 5 bands each)
     this.eqStates = Array.from({ length: MAX_CHANNELS }, () =>
       Array.from({ length: 5 }, () => ({ x1: 0, x2: 0, y1: 0, y2: 0 }))
     );
@@ -119,63 +79,14 @@ class QuantumProcessor extends AudioWorkletProcessor {
     }));
     this.eqDirty = true;
 
-    // --- Pitch correction (quantize / autotune) state ---
-    this.quantizeGrainSize = 1024;
-    this.quantizeBufSize = 4096;
-    this.quantizeBuffers = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(4096));
-    this.quantizeWritePos = new Array(MAX_CHANNELS).fill(0);
-    this.quantizeDelayTaps = Array.from(
-      { length: MAX_CHANNELS },
-      () => [this.quantizeGrainSize * 0.25, this.quantizeGrainSize * 0.75],
-    );
-    this.quantizeTargetRatio = 1.0;
-    this.quantizeSmoothedRatio = 1.0;
-    this.quantizeHeldTargetFreq = 0.0;
-    this.quantizeCandidateTargetFreq = 0.0;
-    this.quantizeCandidateCount = 0;
-    this.quantizeMissingCount = 3;
-    this.quantizeDetectorEnv = 0.0;
-    this.quantizeSubPhase = 0.0;
-    this.quantizeSubGain = 0.0;
-    this.quantizeSubCutHz = 110.0;
-    this.quantizeAirCutHz = 5000.0;
-    this.quantizeDetectorHighHz = 3000.0;
-    this.quantizeMinConfidence = 0.72;
-    this.quantizeMinEnv = 0.01;
-    this.quantizeChangeCents = 40.0;
-    this.quantizeConfirmFrames = 3;
-    this.quantizeReleaseFrames = 2;
-    this.quantizeLowState = new Array(MAX_CHANNELS).fill(0.0);
-    this.quantizeBodyLpState = new Array(MAX_CHANNELS).fill(0.0);
-    this.quantizeDetectorLpState = new Array(MAX_CHANNELS).fill(0.0);
-
-    // Deferred air/sub samples for post-chain mixing
-    this.deferredAir = new Array(MAX_CHANNELS).fill(0.0);
-    this.deferredSubOsc = 0.0;
-
-    // YIN pitch detection buffers
-    this.yinBufSize = 2048;
-    this.yinBuffer = new Float32Array(2048);
-    this.yinWritePos = 0;
-    this.yinTempBuffer = new Float32Array(961); // tau range 0..960
-    this.pitchDetectCounter = 0;
-    this.pitchDetectInterval = 512; // detect pitch every ~10ms at 48kHz
-    this.detectedPitch = 0;
-
-    // --- Parametric EQ (key-aware) state ---
-    // peqInstances param is an array of { id, enabled, mode, key, scale, amount, q }
-    // For each instance we precompute biquad filters targeting in-key or out-of-key notes
     this.peqMaxInstances = 8;
-    this.peqMaxFilters = 60; // 12 pitch classes × 5 octaves
+    this.peqMaxFilters = 60;
     this.peqOctaveStart = 2;
     this.peqOctaveEnd = 6;
-    // Coefficients: [instance][filter] = { b0, b1, b2, a1, a2 }
     this.peqCoeffs = Array.from({ length: this.peqMaxInstances }, () =>
       Array.from({ length: this.peqMaxFilters }, () => ({ b0: 1, b1: 0, b2: 0, a1: 0, a2: 0 }))
     );
-    // Filter count per instance (how many filters are active)
     this.peqFilterCounts = new Array(this.peqMaxInstances).fill(0);
-    // Per-channel filter states: [channel][instance][filter] = { x1, x2, y1, y2 }
     this.peqStates = Array.from({ length: MAX_CHANNELS }, () =>
       Array.from({ length: this.peqMaxInstances }, () =>
         Array.from({ length: this.peqMaxFilters }, () => ({ x1: 0, x2: 0, y1: 0, y2: 0 }))
@@ -183,17 +94,28 @@ class QuantumProcessor extends AudioWorkletProcessor {
     );
     this.peqDirty = true;
 
-    // FFT for spectrum analysis (sent to UI)
+    this.blockInputScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(128));
+    this.blockRetuneScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(128));
+
     this.analysisSamples = new Float32Array(2048);
     this.analysisWritePos = 0;
     this.frameCount = 0;
 
-    this.port.onmessage = (e) => {
-      if (e.data.type === 'params') {
-        Object.assign(this.params, e.data.params);
-        this.eqDirty = true;
-        this.peqDirty = true;
+    this.retuneCore = new PolyphonicRetuneCore({
+      sampleRate,
+      maxChannels: MAX_CHANNELS,
+    });
+
+    this.port.onmessage = (event) => {
+      if (event.data.type !== 'params') {
+        return;
       }
+
+      const retunePatch = normalizeRetuneParamPatch(event.data.params, this.params);
+      Object.assign(this.params, event.data.params, retunePatch);
+      this.retuneCore.setParams(retunePatch);
+      this.eqDirty = true;
+      this.peqDirty = true;
     };
   }
 
@@ -201,7 +123,14 @@ class QuantumProcessor extends AudioWorkletProcessor {
     return [];
   }
 
-  // Compute biquad EQ coefficients for all filter types
+  ensureBlockScratch(length) {
+    if (this.blockInputScratch[0].length === length) {
+      return;
+    }
+    this.blockInputScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(length));
+    this.blockRetuneScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(length));
+  }
+
   computeEQCoeffs() {
     const sr = sampleRate;
     for (let i = 0; i < 5; i++) {
@@ -212,7 +141,7 @@ class QuantumProcessor extends AudioWorkletProcessor {
       const type = band.type || 'peak';
 
       const A = Math.pow(10, gainDB / 40);
-      const w0 = 2 * Math.PI * f0 / sr;
+      const w0 = TWO_PI * f0 / sr;
       const sinW = Math.sin(w0);
       const cosW = Math.cos(w0);
       const alpha = sinW / (2 * Q);
@@ -228,7 +157,6 @@ class QuantumProcessor extends AudioWorkletProcessor {
           a1 = -2 * cosW;
           a2 = 1 - alpha / A;
           break;
-
         case 'lowshelf': {
           const twoSqrtAAlpha = 2 * Math.sqrt(A) * alpha;
           b0 = A * ((A + 1) - (A - 1) * cosW + twoSqrtAAlpha);
@@ -239,7 +167,6 @@ class QuantumProcessor extends AudioWorkletProcessor {
           a2 = (A + 1) + (A - 1) * cosW - twoSqrtAAlpha;
           break;
         }
-
         case 'highshelf': {
           const twoSqrtAAlpha = 2 * Math.sqrt(A) * alpha;
           b0 = A * ((A + 1) + (A - 1) * cosW + twoSqrtAAlpha);
@@ -250,7 +177,6 @@ class QuantumProcessor extends AudioWorkletProcessor {
           a2 = (A + 1) - (A - 1) * cosW - twoSqrtAAlpha;
           break;
         }
-
         case 'lowpass':
           b0 = (1 - cosW) / 2;
           b1 = 1 - cosW;
@@ -259,7 +185,6 @@ class QuantumProcessor extends AudioWorkletProcessor {
           a1 = -2 * cosW;
           a2 = 1 - alpha;
           break;
-
         case 'highpass':
           b0 = (1 + cosW) / 2;
           b1 = -(1 + cosW);
@@ -268,16 +193,13 @@ class QuantumProcessor extends AudioWorkletProcessor {
           a1 = -2 * cosW;
           a2 = 1 - alpha;
           break;
-
         default:
-          // Fallback to peaking
-          b0 = 1 + alpha * A;
-          b1 = -2 * cosW;
-          b2 = 1 - alpha * A;
-          a0 = 1 + alpha / A;
-          a1 = -2 * cosW;
-          a2 = 1 - alpha / A;
-          break;
+          b0 = 1;
+          b1 = 0;
+          b2 = 0;
+          a0 = 1;
+          a1 = 0;
+          a2 = 0;
       }
 
       this.eqCoeffs[i] = {
@@ -291,7 +213,6 @@ class QuantumProcessor extends AudioWorkletProcessor {
     this.eqDirty = false;
   }
 
-  // Compute biquad coefficients for all active PEQ (key-aware) instances
   computePeqCoeffs() {
     const sr = sampleRate;
     const instances = this.params.peqInstances || [];
@@ -302,47 +223,39 @@ class QuantumProcessor extends AudioWorkletProcessor {
         continue;
       }
 
-      const cfg = instances[inst];
-      const scale = SCALES[cfg.scale] || SCALES.major;
-      const key = cfg.key || 0;
-      const amount = cfg.amount || 0;
-      const Q = Math.max(cfg.q || 2.0, 0.1);
-      const isBoost = cfg.mode === 'boost';
-
-      // Gain in dB: amount 0-1 maps to 0-18 dB
+      const config = instances[inst];
+      const scale = SCALES[config.scale] || SCALES.major;
+      const key = config.key || 0;
+      const amount = config.amount || 0;
+      const Q = Math.max(config.q || 2.0, 0.1);
+      const isBoost = config.mode === 'boost';
       const gainDB = amount * 18;
       if (gainDB < 0.1) {
         this.peqFilterCounts[inst] = 0;
         continue;
       }
 
-      // Determine which pitch classes are in the scale
-      const inScale = new Set(scale.map(s => (key + s) % 12));
-
-      let filterIdx = 0;
+      const inScale = new Set(scale.map(interval => (key + interval) % 12));
+      let filterIndex = 0;
       for (let octave = this.peqOctaveStart; octave <= this.peqOctaveEnd; octave++) {
         for (let pc = 0; pc < 12; pc++) {
-          const isInKey = inScale.has(pc);
-          // Boost mode: filter in-key notes (positive gain)
-          // Cut mode: filter out-of-key notes (negative gain)
-          const shouldFilter = isBoost ? isInKey : !isInKey;
-          if (!shouldFilter) continue;
-          if (filterIdx >= this.peqMaxFilters) break;
+          const shouldFilter = isBoost ? inScale.has(pc) : !inScale.has(pc);
+          if (!shouldFilter || filterIndex >= this.peqMaxFilters) {
+            continue;
+          }
 
           const midi = (octave + 1) * 12 + pc;
           const freq = 440 * Math.pow(2, (midi - 69) / 12);
+          if (freq < 30 || freq > sr * 0.45) {
+            continue;
+          }
 
-          // Skip frequencies outside useful range
-          if (freq < 30 || freq > sr * 0.45) continue;
-
-          // Compute peak biquad coefficients
           const appliedGain = isBoost ? gainDB : -gainDB;
           const A = Math.pow(10, appliedGain / 40);
-          const w0 = 2 * Math.PI * freq / sr;
+          const w0 = TWO_PI * freq / sr;
           const sinW = Math.sin(w0);
           const cosW = Math.cos(w0);
           const alpha = sinW / (2 * Q);
-
           const b0 = 1 + alpha * A;
           const b1 = -2 * cosW;
           const b2 = 1 - alpha * A;
@@ -350,44 +263,45 @@ class QuantumProcessor extends AudioWorkletProcessor {
           const a1 = -2 * cosW;
           const a2 = 1 - alpha / A;
 
-          this.peqCoeffs[inst][filterIdx] = {
-            b0: b0 / a0, b1: b1 / a0, b2: b2 / a0,
-            a1: a1 / a0, a2: a2 / a0,
+          this.peqCoeffs[inst][filterIndex] = {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
           };
-          filterIdx++;
+          filterIndex++;
         }
       }
-      this.peqFilterCounts[inst] = filterIdx;
+      this.peqFilterCounts[inst] = filterIndex;
     }
+
     this.peqDirty = false;
   }
 
-  // Apply a single biquad filter sample
   biquad(sample, coeffs, state) {
-    const out = coeffs.b0 * sample + coeffs.b1 * state.x1 + coeffs.b2 * state.x2
+    const output = coeffs.b0 * sample + coeffs.b1 * state.x1 + coeffs.b2 * state.x2
       - coeffs.a1 * state.y1 - coeffs.a2 * state.y2;
     state.x2 = state.x1;
     state.x1 = sample;
     state.y2 = state.y1;
-    state.y1 = out;
-    return out;
+    state.y1 = output;
+    return output;
   }
 
-  // Tape saturation: soft-clip with harmonics
-  tapeSaturate(x, drive) {
+  tapeSaturate(sample, drive) {
     const range = this.params._devDriveRange;
     const d = 1 + drive * 20 * range;
-    const driven = x * d;
+    const driven = sample * d;
     const raw = Math.tanh(driven);
     const normalized = raw / Math.tanh(d);
     return normalized * 0.4 + raw * 0.6;
   }
 
-  // Tube saturation: asymmetric soft-clip
-  tubeSaturate(x, drive) {
+  tubeSaturate(sample, drive) {
     const range = this.params._devDriveRange;
     const d = 1 + drive * 25 * range;
-    const driven = x * d;
+    const driven = sample * d;
     if (driven >= 0) {
       const raw = Math.tanh(driven * 1.2);
       return raw * 0.7 + (raw / Math.tanh(d * 1.2)) * 0.3;
@@ -396,17 +310,12 @@ class QuantumProcessor extends AudioWorkletProcessor {
     return raw * 0.7 + (raw / Math.tanh(d * 0.8)) * 0.3;
   }
 
-  // Wavefold distortion
-  wavefold(x, drive) {
+  wavefold(sample, drive) {
     const range = this.params._devDriveRange;
     const d = 1 + drive * 20 * range;
-    let s = x * d;
-    // Triangle wavefold
-    s = Math.asin(Math.sin(s * Math.PI / 2)) * 2 / Math.PI;
-    return s;
+    return Math.asin(Math.sin(sample * d * Math.PI / 2)) * 2 / Math.PI;
   }
 
-  // Apply saturation with tilt for a given stage
   applySaturation(sample, drive, type, tilt) {
     switch (type) {
       case 'tape':
@@ -420,239 +329,12 @@ class QuantumProcessor extends AudioWorkletProcessor {
         break;
     }
 
-    // Tilt: simple high-shelf approximation
     const t = (tilt - 0.5) * 2;
     if (Math.abs(t) > 0.01) {
-      sample = sample * (1 + t * 0.3);
+      sample *= (1 + t * 0.3);
     }
 
     return sample;
-  }
-
-  onePoleLowpass(sample, cutoff, stateArray, ch) {
-    const safeCutoff = Math.max(10, Math.min(cutoff, sampleRate * 0.45));
-    const coeff = Math.exp(-2 * Math.PI * safeCutoff / sampleRate);
-    const next = (1 - coeff) * sample + coeff * stateArray[ch];
-    stateArray[ch] = next;
-    return next;
-  }
-
-  splitQuantizeBands(sample, ch) {
-    const sub = this.onePoleLowpass(sample, this.quantizeSubCutHz, this.quantizeLowState, ch);
-    const bodyLp = this.onePoleLowpass(sample, this.quantizeAirCutHz, this.quantizeBodyLpState, ch);
-    const body = bodyLp - sub;
-    const air = sample - bodyLp;
-    const detector = this.onePoleLowpass(body, this.quantizeDetectorHighHz, this.quantizeDetectorLpState, ch);
-    return { sub, body, air, detector };
-  }
-
-  centsBetween(freqA, freqB) {
-    if (freqA <= 0 || freqB <= 0) return 0;
-    return 1200 * Math.log2(freqA / freqB);
-  }
-
-  updateQuantizePitchState(pitch, confidence) {
-    if (pitch > 0 && confidence >= this.quantizeMinConfidence && this.quantizeDetectorEnv >= this.quantizeMinEnv) {
-      this.detectedPitch = pitch;
-      const target = this.nearestScaleFreq(
-        pitch, this.params.quantizeKey, this.params.quantizeScale
-      );
-
-      if (this.quantizeHeldTargetFreq <= 0) {
-        this.quantizeHeldTargetFreq = target;
-        this.quantizeCandidateTargetFreq = 0;
-        this.quantizeCandidateCount = 0;
-      } else {
-        const deltaCents = Math.abs(this.centsBetween(target, this.quantizeHeldTargetFreq));
-        if (deltaCents >= this.quantizeChangeCents) {
-          const candidateDelta = this.quantizeCandidateTargetFreq > 0
-            ? Math.abs(this.centsBetween(target, this.quantizeCandidateTargetFreq))
-            : Infinity;
-          if (this.quantizeCandidateTargetFreq > 0 && candidateDelta < 20) {
-            this.quantizeCandidateCount++;
-          } else {
-            this.quantizeCandidateTargetFreq = target;
-            this.quantizeCandidateCount = 1;
-          }
-          if (this.quantizeCandidateCount >= this.quantizeConfirmFrames) {
-            this.quantizeHeldTargetFreq = this.quantizeCandidateTargetFreq;
-            this.quantizeCandidateTargetFreq = 0;
-            this.quantizeCandidateCount = 0;
-          }
-        } else {
-          this.quantizeCandidateTargetFreq = 0;
-          this.quantizeCandidateCount = 0;
-        }
-      }
-
-      const rawRatio = this.quantizeHeldTargetFreq / pitch;
-      this.quantizeTargetRatio = Math.max(0.5, Math.min(2.0, rawRatio));
-      this.quantizeMissingCount = 0;
-      return;
-    }
-
-    this.quantizeMissingCount++;
-    if (this.quantizeMissingCount > this.quantizeReleaseFrames) {
-      this.quantizeHeldTargetFreq = 0;
-      this.quantizeCandidateTargetFreq = 0;
-      this.quantizeCandidateCount = 0;
-      this.quantizeTargetRatio = 1.0;
-    }
-  }
-
-  computeSubFrequency() {
-    const scale = SCALES[this.params.quantizeScale] || SCALES.major;
-    let pitchClass = this.params.quantizeKey;
-
-    if (this.params.quantizeSubSource === 'manual') {
-      // Manual note is an index into the scale, so sub is always in-key
-      const idx = Math.max(0, Math.min(scale.length - 1, Math.round(this.params.quantizeSubNote)));
-      pitchClass = (this.params.quantizeKey + scale[idx]) % 12;
-    } else if (this.params.quantizeSubSource === 'scale_degree') {
-      const degree = Math.max(0, Math.min(scale.length - 1, Math.round(this.params.quantizeSubDegree)));
-      pitchClass = (this.params.quantizeKey + scale[degree]) % 12;
-    }
-
-    const octave = Math.max(0, Math.min(4, Math.round(this.params.quantizeSubOctave)));
-    const midi = 12 * (octave + 1) + pitchClass;
-    return 440 * Math.pow(2, (midi - 69) / 12);
-  }
-
-  // --- YIN pitch detection algorithm ---
-  // Returns detected pitch in Hz, or 0 if no pitch found
-  detectPitch() {
-    const buf = this.yinBuffer;
-    const W = this.yinBufSize;
-    const temp = this.yinTempBuffer;
-    const minTau = 12;   // ~4000 Hz at 48kHz
-    const maxTau = 960;  // ~50 Hz at 48kHz
-    const integrationLen = W - maxTau;
-
-    // Step 1: Difference function
-    for (let tau = 0; tau <= maxTau; tau++) {
-      let sum = 0;
-      for (let j = 0; j < integrationLen; j++) {
-        const idx1 = (this.yinWritePos + j) & (W - 1);
-        const idx2 = (this.yinWritePos + j + tau) & (W - 1);
-        const diff = buf[idx1] - buf[idx2];
-        sum += diff * diff;
-      }
-      temp[tau] = sum;
-    }
-
-    // Step 2: Cumulative mean normalized difference function
-    temp[0] = 1;
-    let runningSum = 0;
-    for (let tau = 1; tau <= maxTau; tau++) {
-      runningSum += temp[tau];
-      temp[tau] = runningSum > 0 ? (temp[tau] * tau) / runningSum : 1;
-    }
-
-    // Step 3: Absolute threshold — find first dip below threshold
-    const threshold = 0.15;
-    let tauEstimate = -1;
-    for (let tau = minTau; tau <= maxTau; tau++) {
-      if (temp[tau] < threshold) {
-        // Walk to the local minimum
-        while (tau + 1 <= maxTau && temp[tau + 1] < temp[tau]) {
-          tau++;
-        }
-        tauEstimate = tau;
-        break;
-      }
-    }
-
-    if (tauEstimate === -1) return { pitch: 0, confidence: 0 };
-
-    // Step 4: Parabolic interpolation for sub-sample accuracy
-    let betterTau = tauEstimate;
-    if (tauEstimate > minTau && tauEstimate < maxTau) {
-      const s0 = temp[tauEstimate - 1];
-      const s1 = temp[tauEstimate];
-      const s2 = temp[tauEstimate + 1];
-      const denom = 2 * (s0 - 2 * s1 + s2);
-      if (Math.abs(denom) > 1e-10) {
-        betterTau = tauEstimate + (s0 - s2) / denom;
-      }
-    }
-
-    // Step 5: Convert period to Hz
-    const pitch = sampleRate / betterTau;
-    const confidence = Math.max(0, Math.min(1, 1 - temp[tauEstimate]));
-
-    // Sanity check: musical range only
-    if (pitch < 50 || pitch > 4000) return { pitch: 0, confidence: 0 };
-
-    return { pitch, confidence };
-  }
-
-  // Find the nearest frequency in the given musical scale
-  nearestScaleFreq(freq, key, scaleName) {
-    if (freq <= 0) return freq;
-
-    const scale = SCALES[scaleName] || SCALES.major;
-
-    // Convert frequency to continuous MIDI note number
-    const midiNote = 12 * Math.log2(freq / 440) + 69;
-
-    // Determine which octave (12-note group) relative to the key
-    const noteInOctave = ((midiNote - key) % 12 + 12) % 12;
-    const octaveBase = midiNote - noteInOctave;
-
-    let bestNote = Math.round(midiNote);
-    let bestDist = 100;
-
-    // Check scale degrees in current octave and neighbors
-    for (let octOff = -1; octOff <= 1; octOff++) {
-      for (const interval of scale) {
-        const candidate = octaveBase + interval + octOff * 12;
-        const dist = Math.abs(midiNote - candidate);
-        if (dist < bestDist) {
-          bestDist = dist;
-          bestNote = candidate;
-        }
-      }
-    }
-
-    return 440 * Math.pow(2, (bestNote - 69) / 12);
-  }
-
-  // Dual-tap variable-delay pitch shifter tuned for small correction moves
-  pitchShiftSample(sample, ch) {
-    const maxDelay = this.quantizeGrainSize;
-    const bufSize = this.quantizeBufSize;
-    const buf = this.quantizeBuffers[ch];
-    const ratio = this.quantizeSmoothedRatio;
-    const slope = 1.0 - ratio;
-
-    // Write input sample to circular buffer
-    buf[this.quantizeWritePos[ch]] = sample;
-
-    let out = 0;
-    let weightSum = 0;
-
-    for (let tap = 0; tap < 2; tap++) {
-      this.quantizeDelayTaps[ch][tap] += slope;
-      while (this.quantizeDelayTaps[ch][tap] < 0) {
-        this.quantizeDelayTaps[ch][tap] += maxDelay;
-      }
-      while (this.quantizeDelayTaps[ch][tap] >= maxDelay) {
-        this.quantizeDelayTaps[ch][tap] -= maxDelay;
-      }
-
-      const phase = this.quantizeDelayTaps[ch][tap] / maxDelay;
-      const windowVal = 0.5 * (1 - Math.cos(2 * Math.PI * phase));
-      const readPos = (this.quantizeWritePos[ch] - this.quantizeDelayTaps[ch][tap] + bufSize) % bufSize;
-      const idx0 = Math.floor(readPos) & (bufSize - 1);
-      const idx1 = (idx0 + 1) & (bufSize - 1);
-      const frac = readPos - idx0;
-      const readSample = buf[idx0] * (1 - frac) + buf[idx1] * frac;
-      out += readSample * windowVal;
-      weightSum += windowVal;
-    }
-
-    this.quantizeWritePos[ch] = (this.quantizeWritePos[ch] + 1) & (bufSize - 1);
-    return weightSum > 1e-6 ? out / weightSum : 0;
   }
 
   process(inputs, outputs, _parameters) {
@@ -664,20 +346,15 @@ class QuantumProcessor extends AudioWorkletProcessor {
     }
 
     const numChannels = Math.min(input.length, output.length, MAX_CHANNELS);
-    const len = input[0].length;
+    const length = input[0].length;
+    this.ensureBlockScratch(length);
 
-    // --- Bypass: pass all channels through unchanged ---
     if (this.params.bypass) {
       for (let ch = 0; ch < numChannels; ch++) {
-        for (let i = 0; i < input[ch].length; i++) {
-          output[ch][i] = input[ch][i];
-        }
+        output[ch].set(input[ch]);
       }
-      // Zero-fill any extra output channels
       for (let ch = numChannels; ch < output.length; ch++) {
-        for (let i = 0; i < output[ch].length; i++) {
-          output[ch][i] = 0;
-        }
+        output[ch].fill(0);
       }
       this.sendAnalysis(input[0]);
       return true;
@@ -690,135 +367,89 @@ class QuantumProcessor extends AudioWorkletProcessor {
       this.computePeqCoeffs();
     }
 
-    for (let i = 0; i < len; i++) {
-      let monoSubSample = 0;
+    for (let ch = 0; ch < numChannels; ch++) {
+      const channelInput = input[ch];
+      const blockBuffer = this.blockInputScratch[ch];
+      const eqStates = this.eqStates[ch];
+      const peqInstances = this.params.peqInstances || [];
 
-      for (let ch = 0; ch < numChannels; ch++) {
-        const channelIn = input[ch];
-        const channelOut = output[ch];
-        const delayBuf = this.delayBuffers[ch];
-        const eqChStates = this.eqStates[ch];
+      for (let i = 0; i < length; i++) {
+        let sample = channelInput[i];
 
-        let sample = channelIn[i];
-        const dry = sample;
-
-        // --- EQ ---
         if (this.params.eqEnabled) {
-          for (let b = 0; b < 5; b++) {
-            const bandType = this.params.eqBands[b].type || 'peak';
-            if (bandType === 'lowpass' || bandType === 'highpass' || this.params.eqBands[b].gain !== 0) {
-              sample = this.biquad(sample, this.eqCoeffs[b], eqChStates[b]);
+          for (let band = 0; band < 5; band++) {
+            const bandType = this.params.eqBands[band].type || 'peak';
+            if (bandType === 'lowpass' || bandType === 'highpass' || this.params.eqBands[band].gain !== 0) {
+              sample = this.biquad(sample, this.eqCoeffs[band], eqStates[band]);
             }
           }
         }
 
-        // --- Parametric EQ (key-aware) ---
-        const peqInstances = this.params.peqInstances || [];
         for (let inst = 0; inst < peqInstances.length && inst < this.peqMaxInstances; inst++) {
           const filterCount = this.peqFilterCounts[inst];
-          if (filterCount > 0) {
-            const instStates = this.peqStates[ch][inst];
-            const instCoeffs = this.peqCoeffs[inst];
-            for (let f = 0; f < filterCount; f++) {
-              sample = this.biquad(sample, instCoeffs[f], instStates[f]);
-            }
+          if (filterCount <= 0) {
+            continue;
+          }
+          const instanceStates = this.peqStates[ch][inst];
+          const instanceCoeffs = this.peqCoeffs[inst];
+          for (let filter = 0; filter < filterCount; filter++) {
+            sample = this.biquad(sample, instanceCoeffs[filter], instanceStates[filter]);
           }
         }
 
-        // --- Saturation (stage 1) ---
         if (this.params.saturateEnabled) {
           sample = this.applySaturation(
             sample,
             this.params.saturateDrive,
             this.params.saturateType,
-            this.params.saturateTilt
+            this.params.saturateTilt,
           );
         }
 
-        if (this.params.quantizeEnabled) {
-          const bands = this.splitQuantizeBands(sample, ch);
+        blockBuffer[i] = sample;
+      }
+    }
 
-          if (ch === 0) {
-            const detectorAbs = Math.abs(bands.detector);
-            const envLerp = detectorAbs > this.quantizeDetectorEnv ? 0.08 : 0.005;
-            this.quantizeDetectorEnv += (detectorAbs - this.quantizeDetectorEnv) * envLerp;
+    const retuneStart = globalThis.performance?.now?.() ?? 0;
+    const retunedBlock = this.retuneCore.processBlock(
+      this.blockInputScratch,
+      numChannels,
+      length,
+      { lowGain: this.params.lowGain, highGain: this.params.highGain },
+    );
+    const retuneTimeMs = (globalThis.performance?.now?.() ?? retuneStart) - retuneStart;
+    const blockBudgetMs = (length / sampleRate) * 1000;
+    this.retuneCore.setRuntimeHealth({ overloaded: retuneTimeMs > blockBudgetMs * 0.85 });
 
-            this.yinBuffer[this.yinWritePos] = bands.detector;
-            this.yinWritePos = (this.yinWritePos + 1) & (this.yinBufSize - 1);
-            this.pitchDetectCounter++;
-            if (this.pitchDetectCounter >= this.pitchDetectInterval) {
-              this.pitchDetectCounter = 0;
-              const detection = this.detectPitch();
-              this.updateQuantizePitchState(detection.pitch, detection.confidence);
-            }
+    for (let ch = 0; ch < numChannels; ch++) {
+      const channelOutput = output[ch];
+      const channelInput = input[ch];
+      const delayBuffer = this.delayBuffers[ch];
 
-            const strength = this.params.quantizeStrength;
-            const effectiveTarget = 1.0 + strength * (this.quantizeTargetRatio - 1.0);
-            this.quantizeSmoothedRatio += (effectiveTarget - this.quantizeSmoothedRatio) * 0.01;
-            this.quantizeSmoothedRatio = Math.max(0.5, Math.min(2.0, this.quantizeSmoothedRatio));
+      for (let i = 0; i < length; i++) {
+        const dry = channelInput[i];
+        let sample = retunedBlock[ch][i];
 
-            // Generate sub oscillator sample (deferred — mixed in after sat2)
-            if (this.params.quantizeSubEnabled) {
-              const subFreq = this.computeSubFrequency();
-              const targetGain = Math.min(1.0, this.quantizeDetectorEnv * 4.0) * this.params.quantizeSubLevel;
-              this.quantizeSubGain += (targetGain - this.quantizeSubGain) * 0.02;
-              this.quantizeSubPhase += (2 * Math.PI * subFreq) / sampleRate;
-              if (this.quantizeSubPhase > 2 * Math.PI) this.quantizeSubPhase -= 2 * Math.PI;
-              this.deferredSubOsc = Math.sin(this.quantizeSubPhase) * this.quantizeSubGain;
-            } else {
-              this.quantizeSubGain += (0 - this.quantizeSubGain) * 0.05;
-              this.deferredSubOsc = 0;
-            }
-          }
-
-          const shiftedBody = this.pitchShiftSample(bands.body, ch);
-          const correctedBody = Math.abs(this.quantizeSmoothedRatio - 1.0) < 0.015
-            ? bands.body
-            : shiftedBody;
-
-          // Pass through original sub + corrected body only; air and sub osc deferred
-          sample = bands.sub + correctedBody;
-          this.deferredAir[ch] = bands.air;
-        } else {
-          // Quantize disabled — no air to defer
-          this.deferredAir[ch] = 0;
-          this.deferredSubOsc = 0;
-          if (ch === 0) {
-            this.quantizeDetectorEnv *= 0.995;
-            this.quantizeSubGain *= 0.95;
-            this.quantizeTargetRatio += (1.0 - this.quantizeTargetRatio) * 0.05;
-            this.quantizeSmoothedRatio += (1.0 - this.quantizeSmoothedRatio) * 0.05;
-            this.quantizeHeldTargetFreq = 0.0;
-            this.quantizeCandidateTargetFreq = 0.0;
-            this.quantizeCandidateCount = 0;
-            this.quantizeMissingCount = this.quantizeReleaseFrames + 1;
-          }
-        }
-
-        // --- Delay ---
         if (this.params.delayEnabled) {
           const delaySamples = Math.floor(this.params.delayTime * sampleRate);
-          const readIndex = (this.delayWriteIndexes[ch] - delaySamples + delayBuf.length) % delayBuf.length;
-          const delayed = delayBuf[readIndex];
-          delayBuf[this.delayWriteIndexes[ch]] = sample + delayed * this.params.delayFeedback;
-          this.delayWriteIndexes[ch] = (this.delayWriteIndexes[ch] + 1) % delayBuf.length;
-          sample = sample + delayed * 0.5;
+          const readIndex = (this.delayWriteIndexes[ch] - delaySamples + delayBuffer.length) % delayBuffer.length;
+          const delayed = delayBuffer[readIndex];
+          delayBuffer[this.delayWriteIndexes[ch]] = sample + delayed * this.params.delayFeedback;
+          this.delayWriteIndexes[ch] = (this.delayWriteIndexes[ch] + 1) % delayBuffer.length;
+          sample += delayed * 0.5;
         }
 
-        // --- Chorus Modulation ---
         if (this.params.modEnabled) {
           const depth = this.params.modDepth * 0.005 * sampleRate;
-          const lfoVal = Math.sin(2 * Math.PI * this.chorusPhase);
-          const modDelay = Math.floor(depth * (1 + lfoVal) + 0.002 * sampleRate);
-          const modReadIndex = (this.delayWriteIndexes[ch] - modDelay + delayBuf.length) % delayBuf.length;
-          const modSample = delayBuf[modReadIndex] || 0;
+          const lfoValue = Math.sin(TWO_PI * this.chorusPhase);
+          const modDelay = Math.floor(depth * (1 + lfoValue) + 0.002 * sampleRate);
+          const modReadIndex = (this.delayWriteIndexes[ch] - modDelay + delayBuffer.length) % delayBuffer.length;
+          const modSample = delayBuffer[modReadIndex] || 0;
           sample = sample * 0.7 + modSample * 0.3;
         }
 
-        // --- Lo-Fi ---
         if (this.params.lofiEnabled) {
-          const wear = this.params.lofiWear;
-          const holdLength = Math.max(1, Math.floor(1 + wear * 15));
+          const holdLength = Math.max(1, Math.floor(1 + this.params.lofiWear * 15));
           this.lofiHoldCounters[ch]++;
           if (this.lofiHoldCounters[ch] >= holdLength) {
             this.lofiHoldSamples[ch] = sample;
@@ -826,72 +457,64 @@ class QuantumProcessor extends AudioWorkletProcessor {
           }
           sample = this.lofiHoldSamples[ch];
 
-          const wobble = this.params.lofiWobble;
-          if (wobble > 0.01) {
-            const wobbleLFO = Math.sin(this.chorusPhase * 0.3 * 2 * Math.PI) * wobble * 0.15;
-            sample *= (1 + wobbleLFO);
+          if (this.params.lofiWobble > 0.01) {
+            const wobble = Math.sin(this.chorusPhase * 0.3 * TWO_PI) * this.params.lofiWobble * 0.15;
+            sample *= (1 + wobble);
           }
         }
 
-        // --- Saturation (stage 2) ---
         if (this.params.saturate2Enabled) {
           sample = this.applySaturation(
             sample,
             this.params.saturate2Drive,
             this.params.saturate2Type,
-            this.params.saturate2Tilt
+            this.params.saturate2Tilt,
           );
         }
 
-        // --- Sub oscillator (after distortion, with low-end gain) ---
-        if (this.params.quantizeEnabled && this.params.quantizeSubEnabled) {
-          sample += this.deferredSubOsc * this.params.lowGain;
-        }
-
-        // --- Air (end of chain, with high-end gain) ---
-        sample += this.deferredAir[ch] * this.params.quantizeAirMix * this.params.highGain;
-
         sample = dry * (1 - this.params.dryWet) + sample * this.params.dryWet;
         sample *= this.params.masterGain;
-        sample = Math.tanh(sample);
-        channelOut[i] = sample;
-      }
-
-      if (this.params.modEnabled || this.params.lofiEnabled) {
-        this.chorusPhase += this.params.modRate / sampleRate;
-        if (this.chorusPhase > 1) this.chorusPhase -= 1;
+        channelOutput[i] = Math.tanh(sample);
       }
     }
 
-    // Zero-fill any extra output channels
-    for (let ch = numChannels; ch < output.length; ch++) {
-      for (let i = 0; i < output[ch].length; i++) {
-        output[ch][i] = 0;
+    if (this.params.modEnabled || this.params.lofiEnabled) {
+      this.chorusPhase += (this.params.modRate * length) / sampleRate;
+      if (this.chorusPhase > 1) {
+        this.chorusPhase -= Math.floor(this.chorusPhase);
       }
+    }
+
+    for (let ch = numChannels; ch < output.length; ch++) {
+      output[ch].fill(0);
     }
 
     this.sendAnalysis(output[0]);
     return true;
   }
 
-  sendAnalysis(data) {
-    // Accumulate samples for spectrum analysis, send every ~50ms
-    for (let i = 0; i < data.length; i++) {
-      this.analysisSamples[this.analysisWritePos] = data[i];
+  sendAnalysis(channelData) {
+    for (let i = 0; i < channelData.length; i++) {
+      this.analysisSamples[this.analysisWritePos] = channelData[i];
       this.analysisWritePos = (this.analysisWritePos + 1) % this.analysisSamples.length;
     }
 
     this.frameCount++;
-    // Send analysis data roughly every 50ms (at 128 samples/frame @ 48kHz ≈ every 18 frames)
-    if (this.frameCount % 18 === 0) {
-      // Reorder buffer so it's contiguous
-      const ordered = new Float32Array(this.analysisSamples.length);
-      const start = this.analysisWritePos;
-      for (let i = 0; i < ordered.length; i++) {
-        ordered[i] = this.analysisSamples[(start + i) % this.analysisSamples.length];
-      }
-      this.port.postMessage({ type: 'analysis', samples: ordered });
+    if (this.frameCount % 18 !== 0) {
+      return;
     }
+
+    const ordered = new Float32Array(this.analysisSamples.length);
+    const start = this.analysisWritePos;
+    for (let i = 0; i < ordered.length; i++) {
+      ordered[i] = this.analysisSamples[(start + i) % this.analysisSamples.length];
+    }
+
+    this.port.postMessage({ type: 'analysis', samples: ordered });
+    this.port.postMessage({
+      type: 'retune-status',
+      status: this.retuneCore.getStatus(),
+    });
   }
 }
 

--- a/ui/public/worklets/quantum-processor.js
+++ b/ui/public/worklets/quantum-processor.js
@@ -38,6 +38,9 @@ class QuantumProcessor extends AudioWorkletProcessor {
 
       ...DEFAULT_RETUNE_PARAMS,
 
+      subEnabled: true,
+      subLevel: 0.25,
+
       lowGain: 1.0,
       highGain: 1.0,
       _devDriveRange: 0.4,
@@ -96,6 +99,10 @@ class QuantumProcessor extends AudioWorkletProcessor {
 
     this.blockInputScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(128));
     this.blockRetuneScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(128));
+    this.subBlockScratch = new Float32Array(128);
+    this.subPhase = 0;
+    this.subSmoothedFreq = 0;
+    this.subSmoothedLevel = 0;
 
     this.analysisSamples = new Float32Array(2048);
     this.analysisWritePos = 0;
@@ -112,7 +119,14 @@ class QuantumProcessor extends AudioWorkletProcessor {
       }
 
       const retunePatch = normalizeRetuneParamPatch(event.data.params, this.params);
-      Object.assign(this.params, event.data.params, retunePatch);
+      const legacySubPatch = {};
+      if (Object.prototype.hasOwnProperty.call(event.data.params, 'quantizeSubEnabled')) {
+        legacySubPatch.subEnabled = Boolean(event.data.params.quantizeSubEnabled);
+      }
+      if (Object.prototype.hasOwnProperty.call(event.data.params, 'quantizeSubLevel')) {
+        legacySubPatch.subLevel = event.data.params.quantizeSubLevel;
+      }
+      Object.assign(this.params, event.data.params, legacySubPatch, retunePatch);
       this.retuneCore.setParams(retunePatch);
       this.eqDirty = true;
       this.peqDirty = true;
@@ -129,6 +143,29 @@ class QuantumProcessor extends AudioWorkletProcessor {
     }
     this.blockInputScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(length));
     this.blockRetuneScratch = Array.from({ length: MAX_CHANNELS }, () => new Float32Array(length));
+    this.subBlockScratch = new Float32Array(length);
+  }
+
+  renderSubBlock(length, subGuide) {
+    const targetFrequency = this.params.subEnabled ? Math.max(0, subGuide.frequency || 0) : 0;
+    const targetLevel = this.params.subEnabled ? (subGuide.level || 0) * this.params.subLevel : 0;
+
+    for (let i = 0; i < length; i++) {
+      this.subSmoothedFreq += (targetFrequency - this.subSmoothedFreq) * 0.012;
+      this.subSmoothedLevel += (targetLevel - this.subSmoothedLevel) * 0.02;
+
+      if (this.subSmoothedFreq > 1 && this.subSmoothedLevel > 1e-4) {
+        this.subPhase += TWO_PI * this.subSmoothedFreq / sampleRate;
+        if (this.subPhase > TWO_PI) {
+          this.subPhase -= TWO_PI;
+        }
+        this.subBlockScratch[i] = Math.sin(this.subPhase) * this.subSmoothedLevel * 0.42;
+      } else {
+        this.subBlockScratch[i] = 0;
+      }
+    }
+
+    return this.subBlockScratch;
   }
 
   computeEQCoeffs() {
@@ -420,6 +457,7 @@ class QuantumProcessor extends AudioWorkletProcessor {
     const retuneTimeMs = (globalThis.performance?.now?.() ?? retuneStart) - retuneStart;
     const blockBudgetMs = (length / sampleRate) * 1000;
     this.retuneCore.setRuntimeHealth({ overloaded: retuneTimeMs > blockBudgetMs * 0.85 });
+    const subBlock = this.renderSubBlock(length, this.retuneCore.getSubGuide());
 
     for (let ch = 0; ch < numChannels; ch++) {
       const channelOutput = output[ch];
@@ -471,6 +509,8 @@ class QuantumProcessor extends AudioWorkletProcessor {
             this.params.saturate2Tilt,
           );
         }
+
+        sample += subBlock[i];
 
         sample = dry * (1 - this.params.dryWet) + sample * this.params.dryWet;
         sample *= this.params.masterGain;

--- a/ui/public/worklets/retune-core.js
+++ b/ui/public/worklets/retune-core.js
@@ -50,6 +50,8 @@ export const DEFAULT_RETUNE_PARAMS = {
   retuneKey: 0,
   retuneScale: 'major',
   retuneStrength: 0.7,
+  retuneDeadbandCents: 18,
+  retuneConfidenceGate: 0.22,
   retuneTargetMask: buildScaleMask(0, 'major'),
   retuneOutOfMaskMode: 'nearest',
   retunePreserveTransients: true,
@@ -137,6 +139,12 @@ export function normalizeRetuneParamPatch(patch, currentParams = DEFAULT_RETUNE_
 
   if (Object.prototype.hasOwnProperty.call(normalized, 'retuneSubReinforcement')) {
     normalized.retuneSubReinforcement = clamp(Number(normalized.retuneSubReinforcement) || 0, 0, 1);
+  }
+  if (Object.prototype.hasOwnProperty.call(normalized, 'retuneDeadbandCents')) {
+    normalized.retuneDeadbandCents = clamp(Number(normalized.retuneDeadbandCents) || 0, 0, 60);
+  }
+  if (Object.prototype.hasOwnProperty.call(normalized, 'retuneConfidenceGate')) {
+    normalized.retuneConfidenceGate = clamp(Number(normalized.retuneConfidenceGate) || 0, 0, 1);
   }
 
   return normalized;
@@ -743,7 +751,8 @@ export class PolyphonicRetuneCore {
     for (const note of this.trackedNotes) {
       const nextDecision = this.resolveTargetDecision(note.sourceMidi, occupiedPitchClasses);
       let { targetMidi, state } = this.applyTargetHysteresis(note, nextDecision, occupiedPitchClasses);
-      const confidenceFloor = note.isLowEnd ? 0.16 : 0.22;
+      const baseGate = this.params.retuneConfidenceGate ?? 0.22;
+      const confidenceFloor = note.isLowEnd ? Math.max(0.1, baseGate * 0.75) : baseGate;
       const eligibleForMapping = note.confidence >= confidenceFloor && (note.age >= 2 || note.targetLockFrames > 0);
 
       if (state === 'mapped' && !eligibleForMapping) {
@@ -902,8 +911,9 @@ export class PolyphonicRetuneCore {
     }
 
     const centsError = Math.abs(note.sourceMidi - note.targetMidi) * 100;
-    const deadbandCents = note.isLowEnd ? 16 : 18;
-    const fullCorrectionCents = note.isLowEnd ? 54 : 68;
+    const baseDeadband = this.params.retuneDeadbandCents ?? 18;
+    const deadbandCents = note.isLowEnd ? baseDeadband * 0.85 : baseDeadband;
+    const fullCorrectionCents = deadbandCents + (note.isLowEnd ? 38 : 50);
 
     if (centsError <= deadbandCents) {
       return 0;

--- a/ui/public/worklets/retune-core.js
+++ b/ui/public/worklets/retune-core.js
@@ -896,6 +896,26 @@ export class PolyphonicRetuneCore {
     );
   }
 
+  getCorrectionBlend(note) {
+    if (note.state !== 'mapped') {
+      return 0;
+    }
+
+    const centsError = Math.abs(note.sourceMidi - note.targetMidi) * 100;
+    const deadbandCents = note.isLowEnd ? 16 : 18;
+    const fullCorrectionCents = note.isLowEnd ? 54 : 68;
+
+    if (centsError <= deadbandCents) {
+      return 0;
+    }
+    if (centsError >= fullCorrectionCents) {
+      return 1;
+    }
+
+    const normalized = (centsError - deadbandCents) / (fullCorrectionCents - deadbandCents);
+    return normalized * normalized * (3 - 2 * normalized);
+  }
+
   applySpectralRetune(real, imag) {
     const activeNotes = this.getActiveTonalNotes();
     const halfBins = this.tonalMagnitudes.length;
@@ -956,10 +976,22 @@ export class PolyphonicRetuneCore {
         continue;
       }
 
+      const correctionBlend = this.getCorrectionBlend(bestNote);
+      if (correctionBlend <= 1e-3) {
+        this.tonalTargetReal[bin] += sourceReal;
+        this.tonalTargetImag[bin] += sourceImag;
+        continue;
+      }
+
+      const effectiveTargetMidi = bestNote.sourceMidi + (bestNote.targetMidi - bestNote.sourceMidi) * correctionBlend;
       const sourceFreq = midiToFreq(bestNote.sourceMidi);
-      const targetFreq = midiToFreq(bestNote.targetMidi);
+      const targetFreq = midiToFreq(effectiveTargetMidi);
       const ratio = targetFreq / Math.max(sourceFreq, 1e-6);
-      const moveAmount = clamp(strengthBase * textureScalar * Math.min(1, bestScore * 1.5), 0, 1);
+      const moveAmount = clamp(
+        strengthBase * textureScalar * correctionBlend * Math.min(1, bestScore * 1.5),
+        0,
+        1,
+      );
       const stayAmount = 1 - moveAmount;
 
       this.tonalTargetReal[bin] += sourceReal * stayAmount;
@@ -1036,7 +1068,10 @@ export class PolyphonicRetuneCore {
     let strongestWeight = 0;
 
     for (const note of lowNotes) {
-      const targetMidi = note.state === 'mapped' ? note.targetMidi : note.sourceMidi;
+      const correctionBlend = this.getCorrectionBlend(note);
+      const targetMidi = note.state === 'mapped'
+        ? note.sourceMidi + (note.targetMidi - note.sourceMidi) * correctionBlend
+        : note.sourceMidi;
       const targetFreq = midiToFreq(targetMidi);
       const weight = clamp(note.energy / Math.max(totalEnergy, 1e-6), 0, 1) * note.confidence;
       if (weight > strongestWeight) {

--- a/ui/public/worklets/retune-core.js
+++ b/ui/public/worklets/retune-core.js
@@ -297,6 +297,7 @@ function makeTrackedNote(id, candidate) {
     state: 'mapped',
     age: 0,
     missingFrames: 0,
+    targetLockFrames: 0,
     phases: [0, 0, 0],
   };
 }
@@ -395,7 +396,19 @@ export class PolyphonicRetuneCore {
       retuneTargetMask: normalized.retuneTargetMask ? cloneMask(normalized.retuneTargetMask) : cloneMask(this.params.retuneTargetMask),
     };
     const enabledChanged = nextParams.retuneEnabled !== this.params.retuneEnabled;
+    const mappingChanged = (
+      nextParams.retuneKey !== this.params.retuneKey
+      || nextParams.retuneScale !== this.params.retuneScale
+      || nextParams.retuneOutOfMaskMode !== this.params.retuneOutOfMaskMode
+      || nextParams.retuneCollapseDuplicates !== this.params.retuneCollapseDuplicates
+      || nextParams.retuneTargetMask.some((enabled, index) => enabled !== this.params.retuneTargetMask[index])
+    );
     this.params = nextParams;
+    if (mappingChanged) {
+      for (const note of this.trackedNotes) {
+        note.targetLockFrames = 0;
+      }
+    }
     if (enabledChanged && !nextParams.retuneEnabled) {
       this.reset();
     }
@@ -615,57 +628,143 @@ export class PolyphonicRetuneCore {
       }
     }
 
-    keptNotes.sort((a, b) => b.energy - a.energy);
+    keptNotes.sort((a, b) => (
+      b.confidence - a.confidence
+      || b.age - a.age
+      || b.energy - a.energy
+      || a.id - b.id
+    ));
     const tonalNotes = keptNotes.filter(note => !note.isLowEnd).slice(0, MAX_TRACKED_NOTES);
     const lowNotes = keptNotes.filter(note => note.isLowEnd).slice(0, MAX_LOW_NOTES);
     this.trackedNotes = [...tonalNotes, ...lowNotes];
     this.assignTargets();
   }
 
+  resolveTargetDecision(sourceMidi, occupiedPitchClasses) {
+    const sourceRounded = Math.round(sourceMidi);
+    const sourcePitchClass = pitchClassForMidi(sourceRounded);
+    const targetMask = this.params.retuneTargetMask;
+    let targetMidi = sourceRounded;
+    let state = 'mapped';
+
+    if (targetMask[sourcePitchClass]) {
+      targetMidi = nearestMidiForPitchClass(sourceMidi, sourcePitchClass);
+    } else {
+      switch (this.params.retuneOutOfMaskMode) {
+        case 'preserve':
+          state = 'preserved';
+          break;
+        case 'mute':
+          state = 'muted';
+          break;
+        default: {
+          const nearest = findNearestAllowedMidi(sourceMidi, targetMask, occupiedPitchClasses);
+          if (nearest === null) {
+            state = 'preserved';
+          } else {
+            targetMidi = nearest;
+          }
+          break;
+        }
+      }
+    }
+
+    return {
+      sourceRounded,
+      state,
+      targetMidi,
+    };
+  }
+
+  applyTargetHysteresis(note, nextDecision, occupiedPitchClasses) {
+    const targetMask = this.params.retuneTargetMask;
+    const previousState = note.state;
+    const previousTarget = note.targetMidi;
+    let { state, targetMidi } = nextDecision;
+
+    if (
+      previousState === 'mapped'
+      && state === 'mapped'
+      && Number.isFinite(previousTarget)
+    ) {
+      const previousPitchClass = pitchClassForMidi(previousTarget);
+      const previousAllowed = targetMask[previousPitchClass];
+      const previousFree = !occupiedPitchClasses || !occupiedPitchClasses.has(previousPitchClass);
+
+      if (previousAllowed && previousFree) {
+        const previousError = Math.abs(note.sourceMidi - previousTarget);
+        const nextError = Math.abs(note.sourceMidi - targetMidi);
+        const improvement = previousError - nextError;
+        const hysteresisMargin = note.confidence < 0.28
+          ? 0.95
+          : note.confidence < 0.45
+            ? 0.6
+            : 0.32;
+        const semitoneStep = Math.abs(targetMidi - previousTarget);
+
+        if (
+          note.targetLockFrames > 0
+          || (semitoneStep <= 2 && improvement < hysteresisMargin)
+        ) {
+          targetMidi = previousTarget;
+        }
+      }
+    }
+
+    if (
+      previousState === 'mapped'
+      && state !== 'mapped'
+      && note.confidence < 0.24
+      && Number.isFinite(previousTarget)
+    ) {
+      const previousPitchClass = pitchClassForMidi(previousTarget);
+      const previousAllowed = targetMask[previousPitchClass];
+      const previousFree = !occupiedPitchClasses || !occupiedPitchClasses.has(previousPitchClass);
+      if (previousAllowed && previousFree) {
+        state = 'mapped';
+        targetMidi = previousTarget;
+      }
+    }
+
+    if (state !== previousState || targetMidi !== previousTarget) {
+      note.targetLockFrames = note.confidence < 0.3 ? 8 : 5;
+    } else {
+      note.targetLockFrames = Math.max(0, note.targetLockFrames - 1);
+    }
+
+    return {
+      state,
+      targetMidi,
+    };
+  }
+
   assignTargets() {
     const occupiedPitchClasses = this.params.retuneCollapseDuplicates ? null : new Set();
-    const targetMask = this.params.retuneTargetMask;
-
     for (const note of this.trackedNotes) {
-      const sourceRounded = Math.round(note.sourceMidi);
-      const sourcePitchClass = pitchClassForMidi(sourceRounded);
-      let targetMidi = sourceRounded;
-      let state = 'mapped';
+      const nextDecision = this.resolveTargetDecision(note.sourceMidi, occupiedPitchClasses);
+      let { targetMidi, state } = this.applyTargetHysteresis(note, nextDecision, occupiedPitchClasses);
+      const confidenceFloor = note.isLowEnd ? 0.16 : 0.22;
+      const eligibleForMapping = note.confidence >= confidenceFloor && (note.age >= 2 || note.targetLockFrames > 0);
 
-      if (targetMask[sourcePitchClass]) {
-        targetMidi = nearestMidiForPitchClass(note.sourceMidi, sourcePitchClass);
-      } else {
-        switch (this.params.retuneOutOfMaskMode) {
-          case 'preserve':
-            targetMidi = sourceRounded;
-            state = 'preserved';
-            break;
-          case 'mute':
-            targetMidi = sourceRounded;
-            state = 'muted';
-            break;
-          default: {
-            const nearest = findNearestAllowedMidi(note.sourceMidi, targetMask, occupiedPitchClasses);
-            if (nearest === null) {
-              targetMidi = sourceRounded;
-              state = 'preserved';
-            } else {
-              targetMidi = nearest;
-            }
-            break;
-          }
+      if (state === 'mapped' && !eligibleForMapping) {
+        if (note.targetLockFrames > 0 && Number.isFinite(note.targetMidi)) {
+          targetMidi = note.targetMidi;
+        } else {
+          state = 'preserved';
+          targetMidi = nextDecision.sourceRounded;
         }
       }
 
       if (!this.params.retuneCollapseDuplicates && state === 'mapped') {
         const targetPitchClass = pitchClassForMidi(targetMidi);
         if (occupiedPitchClasses.has(targetPitchClass)) {
-          const alternate = findNearestAllowedMidi(note.sourceMidi, targetMask, occupiedPitchClasses);
-          if (alternate === null) {
-            state = 'preserved';
-            targetMidi = sourceRounded;
-          } else {
+          const alternate = findNearestAllowedMidi(note.sourceMidi, this.params.retuneTargetMask, occupiedPitchClasses);
+          if (alternate !== null && alternate !== note.targetMidi) {
             targetMidi = alternate;
+            note.targetLockFrames = Math.min(note.targetLockFrames, 2);
+          } else {
+            state = 'preserved';
+            targetMidi = nextDecision.sourceRounded;
           }
         }
         if (state === 'mapped') {
@@ -677,7 +776,12 @@ export class PolyphonicRetuneCore {
       note.state = state;
     }
 
-    this.trackedNotes.sort((a, b) => b.energy - a.energy);
+    this.trackedNotes.sort((a, b) => (
+      b.confidence - a.confidence
+      || b.age - a.age
+      || b.energy - a.energy
+      || a.id - b.id
+    ));
     this.noteCount = this.trackedNotes.length;
     const strongest = this.trackedNotes[0];
     this.detectedPitch = strongest ? midiToFreq(strongest.sourceMidi) : 0;

--- a/ui/public/worklets/retune-core.js
+++ b/ui/public/worklets/retune-core.js
@@ -475,6 +475,27 @@ export class PolyphonicRetuneCore {
     return magnitudes[index] * (1 - frac) + magnitudes[index + 1] * frac;
   }
 
+  computeSpectralFlatness(magnitudes, minBin, maxBin) {
+    let logSum = 0;
+    let linearSum = 0;
+    let count = 0;
+
+    for (let bin = minBin; bin <= maxBin; bin++) {
+      const magnitude = Math.max(magnitudes[bin], 1e-12);
+      logSum += Math.log(magnitude);
+      linearSum += magnitude;
+      count++;
+    }
+
+    if (count === 0 || linearSum <= 0) {
+      return 1;
+    }
+
+    const geometricMean = Math.exp(logSum / count);
+    const arithmeticMean = linearSum / count;
+    return clamp(geometricMean / Math.max(arithmeticMean, 1e-12), 0, 1);
+  }
+
   detectCandidatesFromSpectrum(magnitudes, frameSize, options) {
     const {
       minMidi,
@@ -705,6 +726,12 @@ export class PolyphonicRetuneCore {
     this.transientBypassActive = this.params.retunePreserveTransients && fluxRatio > 0.55;
     this.transientMix = this.transientBypassActive ? 0.35 : 1.0;
     this.detectorEnv += (Math.sqrt(frameEnergy / this.tonalFrameSize) - this.detectorEnv) * 0.18;
+    const tonalFlatness = this.computeSpectralFlatness(
+      this.tonalMagnitudes,
+      2,
+      Math.min(this.tonalMagnitudes.length - 1, Math.floor(5000 * this.tonalFrameSize / this.sampleRate)),
+    );
+    const tonalTonality = clamp((0.82 - tonalFlatness) / 0.62, 0, 1);
 
     const tonalCandidates = this.detectCandidatesFromSpectrum(this.tonalMagnitudes, this.tonalFrameSize, {
       minMidi: 40,
@@ -714,6 +741,9 @@ export class PolyphonicRetuneCore {
       lowCutoffHz: 5000,
       isLowEnd: false,
     });
+    for (const candidate of tonalCandidates) {
+      candidate.confidence *= tonalTonality;
+    }
     this.updateTrackedNotes(tonalCandidates);
   }
 
@@ -735,6 +765,12 @@ export class PolyphonicRetuneCore {
     for (let bin = 0; bin < this.lowMagnitudes.length; bin++) {
       this.lowMagnitudes[bin] = Math.hypot(this.lowReal[bin], this.lowImag[bin]);
     }
+    const lowFlatness = this.computeSpectralFlatness(
+      this.lowMagnitudes,
+      2,
+      Math.min(this.lowMagnitudes.length - 1, Math.floor(320 * this.lowFrameSize / this.sampleRate)),
+    );
+    const lowTonality = clamp((0.9 - lowFlatness) / 0.7, 0, 1);
 
     const lowCandidates = this.detectCandidatesFromSpectrum(this.lowMagnitudes, this.lowFrameSize, {
       minMidi: 28,
@@ -744,6 +780,9 @@ export class PolyphonicRetuneCore {
       lowCutoffHz: 320,
       isLowEnd: true,
     });
+    for (const candidate of lowCandidates) {
+      candidate.confidence *= lowTonality;
+    }
     this.updateTrackedNotes(lowCandidates);
   }
 

--- a/ui/public/worklets/retune-core.js
+++ b/ui/public/worklets/retune-core.js
@@ -59,7 +59,6 @@ export const DEFAULT_RETUNE_PARAMS = {
   retuneLowEndMode: 'hybrid',
   retuneLowEndBlend: 0.55,
   retuneCollapseDuplicates: false,
-  retuneSubReinforcement: 0.25,
   retuneAirMix: 1.0,
 };
 
@@ -69,8 +68,6 @@ const LEGACY_PARAM_ALIASES = {
   quantizeScale: 'retuneScale',
   quantizeStrength: 'retuneStrength',
   quantizeAirMix: 'retuneAirMix',
-  quantizeSubEnabled: 'retuneSubReinforcement',
-  quantizeSubLevel: 'retuneSubReinforcement',
 };
 
 function cloneMask(mask) {
@@ -99,13 +96,7 @@ export function normalizeRetuneParamPatch(patch, currentParams = DEFAULT_RETUNE_
       continue;
     }
 
-    if (key === 'quantizeSubEnabled') {
-      normalized[alias] = value ? currentParams.retuneSubReinforcement : 0;
-    } else if (key === 'quantizeSubLevel') {
-      normalized[alias] = value;
-    } else {
-      normalized[alias] = value;
-    }
+    normalized[alias] = value;
   }
 
   if (Object.prototype.hasOwnProperty.call(normalized, 'retuneScale')) {
@@ -137,9 +128,6 @@ export function normalizeRetuneParamPatch(patch, currentParams = DEFAULT_RETUNE_
     }
   }
 
-  if (Object.prototype.hasOwnProperty.call(normalized, 'retuneSubReinforcement')) {
-    normalized.retuneSubReinforcement = clamp(Number(normalized.retuneSubReinforcement) || 0, 0, 1);
-  }
   if (Object.prototype.hasOwnProperty.call(normalized, 'retuneDeadbandCents')) {
     normalized.retuneDeadbandCents = clamp(Number(normalized.retuneDeadbandCents) || 0, 0, 60);
   }
@@ -378,6 +366,8 @@ export class PolyphonicRetuneCore {
     this.smoothedRatio = 1;
     this.detectorEnv = 0;
     this.confidence = 0;
+    this.subGuideFrequency = 0;
+    this.subGuideLevel = 0;
 
     this.tonalWritePos = 0;
     this.tonalInputSampleCount = 0;
@@ -447,6 +437,8 @@ export class PolyphonicRetuneCore {
     this.smoothedRatio = 1;
     this.detectorEnv = 0;
     this.confidence = 0;
+    this.subGuideFrequency = 0;
+    this.subGuideLevel = 0;
     this.prevTonalMagnitudes.fill(0);
     this.tonalMonoRing.fill(0);
     this.lowMonoRing.fill(0);
@@ -799,6 +791,21 @@ export class PolyphonicRetuneCore {
     this.smoothedRatio += (this.targetRatio - this.smoothedRatio) * 0.18;
     this.confidence = strongest ? strongest.confidence : 0;
     this.lowEndLocked = this.trackedNotes.some(note => note.isLowEnd && note.confidence > 0.18 && note.state !== 'muted');
+
+    const strongestLow = this.trackedNotes.find(
+      (note) => note.isLowEnd && note.confidence > 0.12 && note.state !== 'muted',
+    );
+    if (strongestLow) {
+      const correctionBlend = this.getCorrectionBlend(strongestLow);
+      const effectiveMidi = strongestLow.state === 'mapped'
+        ? strongestLow.sourceMidi + (strongestLow.targetMidi - strongestLow.sourceMidi) * correctionBlend
+        : strongestLow.sourceMidi;
+      this.subGuideFrequency = midiToFreq(effectiveMidi);
+      this.subGuideLevel = clamp(strongestLow.confidence * 0.9, 0, 1);
+    } else {
+      this.subGuideFrequency = 0;
+      this.subGuideLevel = 0;
+    }
   }
 
   analyzeTonalFrame() {
@@ -1074,8 +1081,6 @@ export class PolyphonicRetuneCore {
 
     const totalEnergy = lowNotes.reduce((sum, note) => sum + note.energy, 0);
     let sample = 0;
-    let strongestTarget = 0;
-    let strongestWeight = 0;
 
     for (const note of lowNotes) {
       const correctionBlend = this.getCorrectionBlend(note);
@@ -1084,10 +1089,6 @@ export class PolyphonicRetuneCore {
         : note.sourceMidi;
       const targetFreq = midiToFreq(targetMidi);
       const weight = clamp(note.energy / Math.max(totalEnergy, 1e-6), 0, 1) * note.confidence;
-      if (weight > strongestWeight) {
-        strongestWeight = weight;
-        strongestTarget = targetFreq;
-      }
 
       const harmonicWeights = [1.0, 0.45, 0.18];
       for (let harmonic = 0; harmonic < harmonicWeights.length; harmonic++) {
@@ -1100,15 +1101,15 @@ export class PolyphonicRetuneCore {
       }
     }
 
-    if (this.params.retuneSubReinforcement > 0 && strongestTarget > 0) {
-      this.subPhase = (this.subPhase || 0) + TWO_PI * strongestTarget / this.sampleRate;
-      if (this.subPhase > TWO_PI) {
-        this.subPhase -= TWO_PI;
-      }
-      sample += Math.sin(this.subPhase) * this.params.retuneSubReinforcement * strongestWeight;
-    }
-
     return sample * 0.35;
+  }
+
+  getSubGuide() {
+    return {
+      frequency: this.subGuideFrequency,
+      level: this.subGuideLevel,
+      locked: this.lowEndLocked,
+    };
   }
 
   processBlock(inputBlock, numChannels, length, mix = { lowGain: 1, highGain: 1 }) {

--- a/ui/public/worklets/retune-core.js
+++ b/ui/public/worklets/retune-core.js
@@ -1,0 +1,1024 @@
+export const SCALES = {
+  major: [0, 2, 4, 5, 7, 9, 11],
+  minor: [0, 2, 3, 5, 7, 8, 10],
+  pentatonic: [0, 2, 4, 7, 9],
+  dorian: [0, 2, 3, 5, 7, 9, 10],
+  mixolydian: [0, 2, 4, 5, 7, 9, 10],
+  harmonic_minor: [0, 2, 3, 5, 7, 8, 11],
+  chromatic: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+};
+
+const MAX_TRACKED_NOTES = 8;
+const MAX_LOW_NOTES = 3;
+const MAX_CHANNELS = 2;
+const TWO_PI = Math.PI * 2;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function midiToFreq(midi) {
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+function freqToMidi(freq) {
+  if (freq <= 0) return -Infinity;
+  return 69 + 12 * Math.log2(freq / 440);
+}
+
+function centsBetween(freqA, freqB) {
+  if (freqA <= 0 || freqB <= 0) return 0;
+  return 1200 * Math.log2(freqA / freqB);
+}
+
+function pitchClassForMidi(midi) {
+  return ((Math.round(midi) % 12) + 12) % 12;
+}
+
+export function buildScaleMask(key, scaleName) {
+  const scale = SCALES[scaleName] || SCALES.major;
+  const mask = new Array(12).fill(false);
+  for (let i = 0; i < scale.length; i++) {
+    mask[(key + scale[i] + 12) % 12] = true;
+  }
+  return mask;
+}
+
+export const DEFAULT_RETUNE_PARAMS = {
+  retuneEnabled: false,
+  retuneMode: 'polyphonic',
+  retuneKey: 0,
+  retuneScale: 'major',
+  retuneStrength: 0.7,
+  retuneTargetMask: buildScaleMask(0, 'major'),
+  retuneOutOfMaskMode: 'nearest',
+  retunePreserveTransients: true,
+  retuneTextureAmount: 0.2,
+  retuneLowEndMode: 'hybrid',
+  retuneLowEndBlend: 0.55,
+  retuneCollapseDuplicates: false,
+  retuneSubReinforcement: 0.25,
+  retuneAirMix: 1.0,
+};
+
+const LEGACY_PARAM_ALIASES = {
+  quantizeEnabled: 'retuneEnabled',
+  quantizeKey: 'retuneKey',
+  quantizeScale: 'retuneScale',
+  quantizeStrength: 'retuneStrength',
+  quantizeAirMix: 'retuneAirMix',
+  quantizeSubEnabled: 'retuneSubReinforcement',
+  quantizeSubLevel: 'retuneSubReinforcement',
+};
+
+function cloneMask(mask) {
+  if (!Array.isArray(mask)) {
+    return buildScaleMask(DEFAULT_RETUNE_PARAMS.retuneKey, DEFAULT_RETUNE_PARAMS.retuneScale);
+  }
+  const normalized = new Array(12).fill(false);
+  for (let i = 0; i < 12; i++) {
+    normalized[i] = Boolean(mask[i]);
+  }
+  return normalized;
+}
+
+export function normalizeRetuneParamPatch(patch, currentParams = DEFAULT_RETUNE_PARAMS) {
+  const normalized = {};
+  const source = patch || {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (Object.prototype.hasOwnProperty.call(DEFAULT_RETUNE_PARAMS, key)) {
+      normalized[key] = value;
+      continue;
+    }
+
+    const alias = LEGACY_PARAM_ALIASES[key];
+    if (!alias) {
+      continue;
+    }
+
+    if (key === 'quantizeSubEnabled') {
+      normalized[alias] = value ? currentParams.retuneSubReinforcement : 0;
+    } else if (key === 'quantizeSubLevel') {
+      normalized[alias] = value;
+    } else {
+      normalized[alias] = value;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(normalized, 'retuneScale')) {
+    normalized.retuneScale = normalized.retuneScale in SCALES ? normalized.retuneScale : currentParams.retuneScale;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(normalized, 'retuneTargetMask')) {
+    normalized.retuneTargetMask = cloneMask(normalized.retuneTargetMask);
+  } else if (
+    Object.prototype.hasOwnProperty.call(normalized, 'retuneKey')
+    || Object.prototype.hasOwnProperty.call(normalized, 'retuneScale')
+  ) {
+    const nextKey = Object.prototype.hasOwnProperty.call(normalized, 'retuneKey')
+      ? normalized.retuneKey
+      : currentParams.retuneKey;
+    const nextScale = Object.prototype.hasOwnProperty.call(normalized, 'retuneScale')
+      ? normalized.retuneScale
+      : currentParams.retuneScale;
+    normalized.retuneTargetMask = buildScaleMask(nextKey, nextScale);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(normalized, 'retuneTargetMask')) {
+    const hasAny = normalized.retuneTargetMask.some(Boolean);
+    if (!hasAny) {
+      normalized.retuneTargetMask = buildScaleMask(
+        normalized.retuneKey ?? currentParams.retuneKey,
+        normalized.retuneScale ?? currentParams.retuneScale,
+      );
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(normalized, 'retuneSubReinforcement')) {
+    normalized.retuneSubReinforcement = clamp(Number(normalized.retuneSubReinforcement) || 0, 0, 1);
+  }
+
+  return normalized;
+}
+
+class Radix2FFT {
+  constructor(size) {
+    this.size = size;
+    this.levels = Math.log2(size) | 0;
+    this.bitReverse = new Uint32Array(size);
+    this.cosTable = new Float32Array(size / 2);
+    this.sinTable = new Float32Array(size / 2);
+
+    for (let i = 0; i < size; i++) {
+      let x = i;
+      let y = 0;
+      for (let j = 0; j < this.levels; j++) {
+        y = (y << 1) | (x & 1);
+        x >>= 1;
+      }
+      this.bitReverse[i] = y;
+    }
+
+    for (let i = 0; i < size / 2; i++) {
+      const angle = TWO_PI * i / size;
+      this.cosTable[i] = Math.cos(angle);
+      this.sinTable[i] = Math.sin(angle);
+    }
+  }
+
+  transform(real, imag, inverse = false) {
+    const n = this.size;
+
+    for (let i = 0; i < n; i++) {
+      const j = this.bitReverse[i];
+      if (j > i) {
+        const realTmp = real[i];
+        real[i] = real[j];
+        real[j] = realTmp;
+
+        const imagTmp = imag[i];
+        imag[i] = imag[j];
+        imag[j] = imagTmp;
+      }
+    }
+
+    for (let size = 2; size <= n; size <<= 1) {
+      const halfSize = size >> 1;
+      const tableStep = n / size;
+      for (let start = 0; start < n; start += size) {
+        let tableIndex = 0;
+        for (let i = start; i < start + halfSize; i++) {
+          const j = i + halfSize;
+          const wr = this.cosTable[tableIndex];
+          const wi = inverse ? this.sinTable[tableIndex] : -this.sinTable[tableIndex];
+          const tr = wr * real[j] - wi * imag[j];
+          const ti = wr * imag[j] + wi * real[j];
+
+          real[j] = real[i] - tr;
+          imag[j] = imag[i] - ti;
+          real[i] += tr;
+          imag[i] += ti;
+          tableIndex += tableStep;
+        }
+      }
+    }
+
+    if (inverse) {
+      const inv = 1 / n;
+      for (let i = 0; i < n; i++) {
+        real[i] *= inv;
+        imag[i] *= inv;
+      }
+    }
+  }
+}
+
+function createWindow(size) {
+  const window = new Float32Array(size);
+  for (let i = 0; i < size; i++) {
+    window[i] = 0.5 - 0.5 * Math.cos(TWO_PI * i / size);
+  }
+  return window;
+}
+
+function createSynthesisWindow(window, hopSize) {
+  const size = window.length;
+  const overlapNorm = new Float32Array(size);
+  for (let shift = 0; shift < size; shift += hopSize) {
+    for (let i = 0; i < size; i++) {
+      const idx = (i + shift) % size;
+      overlapNorm[i] += window[idx] * window[idx];
+    }
+  }
+
+  const synthesis = new Float32Array(size);
+  for (let i = 0; i < size; i++) {
+    synthesis[i] = window[i] / Math.max(overlapNorm[i], 1e-6);
+  }
+  return synthesis;
+}
+
+function createRingSet(length, itemLength) {
+  return Array.from({ length }, () => new Float32Array(itemLength));
+}
+
+function nearestMidiForPitchClass(sourceMidi, pitchClass) {
+  const rounded = Math.round(sourceMidi);
+  let bestMidi = rounded;
+  let bestDistance = Infinity;
+
+  for (let candidate = rounded - 24; candidate <= rounded + 24; candidate++) {
+    if (((candidate % 12) + 12) % 12 !== pitchClass) {
+      continue;
+    }
+    const distance = Math.abs(candidate - sourceMidi);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMidi = candidate;
+    }
+  }
+
+  return bestMidi;
+}
+
+function findNearestAllowedMidi(sourceMidi, targetMask, occupiedPitchClasses = null) {
+  const rounded = Math.round(sourceMidi);
+  let bestMidi = rounded;
+  let bestDistance = Infinity;
+
+  for (let candidate = rounded - 24; candidate <= rounded + 24; candidate++) {
+    const pitchClass = ((candidate % 12) + 12) % 12;
+    if (!targetMask[pitchClass]) {
+      continue;
+    }
+    if (occupiedPitchClasses && occupiedPitchClasses.has(pitchClass)) {
+      continue;
+    }
+    const distance = Math.abs(candidate - sourceMidi);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMidi = candidate;
+    }
+  }
+
+  return Number.isFinite(bestDistance) ? bestMidi : null;
+}
+
+function makeTrackedNote(id, candidate) {
+  return {
+    id,
+    sourceMidi: candidate.sourceMidi,
+    targetMidi: candidate.sourceMidi,
+    confidence: clamp(candidate.confidence, 0, 1),
+    energy: candidate.energy,
+    bandwidth: candidate.bandwidth,
+    isLowEnd: candidate.isLowEnd,
+    state: 'mapped',
+    age: 0,
+    missingFrames: 0,
+    phases: [0, 0, 0],
+  };
+}
+
+export class PolyphonicRetuneCore {
+  constructor({ sampleRate, maxChannels = MAX_CHANNELS }) {
+    this.sampleRate = sampleRate;
+    this.maxChannels = maxChannels;
+    this.params = { ...DEFAULT_RETUNE_PARAMS, retuneTargetMask: cloneMask(DEFAULT_RETUNE_PARAMS.retuneTargetMask) };
+
+    this.tonalFrameSize = 4096;
+    this.tonalHopSize = 1024;
+    this.lowFrameSize = 8192;
+    this.lowHopSize = 2048;
+    this.latencySamples = this.tonalFrameSize - this.tonalHopSize;
+    this.analysisLatencyMs = (this.latencySamples / this.sampleRate) * 1000;
+
+    this.tonalRingSize = 16384;
+    this.tonalRingMask = this.tonalRingSize - 1;
+    this.outputRingSize = 32768;
+    this.outputRingMask = this.outputRingSize - 1;
+    this.delayRingSize = 8192;
+    this.delayRingMask = this.delayRingSize - 1;
+
+    this.tonalInputRings = createRingSet(maxChannels, this.tonalRingSize);
+    this.tonalMonoRing = new Float32Array(this.tonalRingSize);
+    this.lowMonoRing = new Float32Array(this.lowFrameSize * 2);
+    this.lowMonoRingMask = this.lowMonoRing.length - 1;
+    this.outputRings = createRingSet(maxChannels, this.outputRingSize);
+    this.airDelayRings = createRingSet(maxChannels, this.delayRingSize);
+
+    this.tonalWindow = createWindow(this.tonalFrameSize);
+    this.tonalSynthesisWindow = createSynthesisWindow(this.tonalWindow, this.tonalHopSize);
+    this.lowWindow = createWindow(this.lowFrameSize);
+
+    this.tonalFFT = new Radix2FFT(this.tonalFrameSize);
+    this.lowFFT = new Radix2FFT(this.lowFrameSize);
+    this.tonalMonoReal = new Float32Array(this.tonalFrameSize);
+    this.tonalMonoImag = new Float32Array(this.tonalFrameSize);
+    this.tonalWorkReal = new Float32Array(this.tonalFrameSize);
+    this.tonalWorkImag = new Float32Array(this.tonalFrameSize);
+    this.tonalTargetReal = new Float32Array(this.tonalFrameSize);
+    this.tonalTargetImag = new Float32Array(this.tonalFrameSize);
+    this.tonalMagnitudes = new Float32Array(this.tonalFrameSize / 2 + 1);
+    this.prevTonalMagnitudes = new Float32Array(this.tonalFrameSize / 2 + 1);
+    this.lowReal = new Float32Array(this.lowFrameSize);
+    this.lowImag = new Float32Array(this.lowFrameSize);
+    this.lowMagnitudes = new Float32Array(this.lowFrameSize / 2 + 1);
+    this.blockInputScratch = createRingSet(maxChannels, this.tonalFrameSize);
+    this.blockOutputScratch = createRingSet(maxChannels, 128);
+
+    this.noteEnergyScratch = new Float32Array(97);
+    this.lowNoteEnergyScratch = new Float32Array(53);
+
+    this.lowCutState = new Array(maxChannels).fill(0);
+    this.airLpState = new Array(maxChannels).fill(0);
+    this.lowBlendState = new Array(maxChannels).fill(0);
+    this.lowAnalysisState = new Array(maxChannels).fill(0);
+
+    this.trackedNotes = [];
+    this.nextTrackedNoteId = 1;
+    this.transientBypassActive = false;
+    this.transientMix = 1.0;
+    this.lowEndLocked = false;
+    this.overloaded = false;
+    this.noteCount = 0;
+    this.detectedPitch = 0;
+    this.targetPitch = 0;
+    this.targetRatio = 1;
+    this.smoothedRatio = 1;
+    this.detectorEnv = 0;
+    this.confidence = 0;
+
+    this.tonalWritePos = 0;
+    this.tonalInputSampleCount = 0;
+    this.tonalSamplesSinceFrame = 0;
+    this.lowWritePos = 0;
+    this.lowSampleCount = 0;
+    this.lowSamplesSinceFrame = 0;
+    this.outputSampleCount = 0;
+    this.delayWritePos = 0;
+  }
+
+  ensureBlockSize(length) {
+    if (this.blockOutputScratch[0].length === length) {
+      return;
+    }
+    this.blockOutputScratch = createRingSet(this.maxChannels, length);
+  }
+
+  setParams(patch) {
+    const normalized = normalizeRetuneParamPatch(patch, this.params);
+    const nextParams = {
+      ...this.params,
+      ...normalized,
+      retuneTargetMask: normalized.retuneTargetMask ? cloneMask(normalized.retuneTargetMask) : cloneMask(this.params.retuneTargetMask),
+    };
+    const enabledChanged = nextParams.retuneEnabled !== this.params.retuneEnabled;
+    this.params = nextParams;
+    if (enabledChanged && !nextParams.retuneEnabled) {
+      this.reset();
+    }
+  }
+
+  setRuntimeHealth({ overloaded }) {
+    this.overloaded = overloaded;
+  }
+
+  reset() {
+    this.tonalWritePos = 0;
+    this.tonalInputSampleCount = 0;
+    this.tonalSamplesSinceFrame = 0;
+    this.lowWritePos = 0;
+    this.lowSampleCount = 0;
+    this.lowSamplesSinceFrame = 0;
+    this.outputSampleCount = 0;
+    this.delayWritePos = 0;
+    this.trackedNotes = [];
+    this.nextTrackedNoteId = 1;
+    this.transientBypassActive = false;
+    this.transientMix = 1;
+    this.lowEndLocked = false;
+    this.noteCount = 0;
+    this.detectedPitch = 0;
+    this.targetPitch = 0;
+    this.targetRatio = 1;
+    this.smoothedRatio = 1;
+    this.detectorEnv = 0;
+    this.confidence = 0;
+    this.prevTonalMagnitudes.fill(0);
+    this.tonalMonoRing.fill(0);
+    this.lowMonoRing.fill(0);
+
+    for (let ch = 0; ch < this.maxChannels; ch++) {
+      this.tonalInputRings[ch].fill(0);
+      this.outputRings[ch].fill(0);
+      this.airDelayRings[ch].fill(0);
+      this.lowCutState[ch] = 0;
+      this.airLpState[ch] = 0;
+      this.lowBlendState[ch] = 0;
+      this.lowAnalysisState[ch] = 0;
+    }
+  }
+
+  onePoleLowpass(sample, cutoff, stateArray, ch) {
+    const safeCutoff = clamp(cutoff, 10, this.sampleRate * 0.45);
+    const coeff = Math.exp(-TWO_PI * safeCutoff / this.sampleRate);
+    const next = (1 - coeff) * sample + coeff * stateArray[ch];
+    stateArray[ch] = next;
+    return next;
+  }
+
+  splitSample(sample, ch) {
+    const lowFloor = this.onePoleLowpass(sample, 35, this.lowCutState, ch);
+    const lowRemoved = sample - lowFloor;
+    const tonal = this.onePoleLowpass(lowRemoved, 5000, this.airLpState, ch);
+    const air = lowRemoved - tonal;
+    const lowSeed = this.onePoleLowpass(tonal, 220, this.lowAnalysisState, ch);
+    return { tonal, air, lowSeed };
+  }
+
+  copyFrameFromRing(ring, writePos, ringMask, frameSize, frameBuffer) {
+    const start = (writePos - frameSize + ring.length) & ringMask;
+    for (let i = 0; i < frameSize; i++) {
+      frameBuffer[i] = ring[(start + i) & ringMask];
+    }
+  }
+
+  magnitudeAtFreq(magnitudes, frameSize, freq) {
+    if (freq <= 0) return 0;
+    const bin = freq * frameSize / this.sampleRate;
+    const maxBin = magnitudes.length - 1;
+    if (bin <= 0 || bin >= maxBin) return 0;
+    const index = Math.floor(bin);
+    const frac = bin - index;
+    return magnitudes[index] * (1 - frac) + magnitudes[index + 1] * frac;
+  }
+
+  detectCandidatesFromSpectrum(magnitudes, frameSize, options) {
+    const {
+      minMidi,
+      maxMidi,
+      maxHarmonics,
+      maxCandidates,
+      lowCutoffHz,
+      isLowEnd,
+    } = options;
+    const scratch = isLowEnd ? this.lowNoteEnergyScratch : this.noteEnergyScratch;
+    scratch.fill(0);
+
+    for (let midi = minMidi; midi <= maxMidi; midi++) {
+      const fundamental = midiToFreq(midi);
+      let energy = 0;
+      let support = 0;
+      for (let harmonic = 1; harmonic <= maxHarmonics; harmonic++) {
+        const harmonicFreq = fundamental * harmonic;
+        if (harmonicFreq >= lowCutoffHz || harmonicFreq >= this.sampleRate * 0.48) {
+          break;
+        }
+        const weight = isLowEnd ? 1 / Math.pow(harmonic, 0.6) : 1 / Math.pow(harmonic, 0.8);
+        const mag = this.magnitudeAtFreq(magnitudes, frameSize, harmonicFreq);
+        const lower = this.magnitudeAtFreq(magnitudes, frameSize, harmonicFreq * Math.pow(2, -25 / 1200));
+        const upper = this.magnitudeAtFreq(magnitudes, frameSize, harmonicFreq * Math.pow(2, 25 / 1200));
+        const prominence = Math.max(0, mag - 0.45 * (lower + upper));
+        energy += prominence * weight;
+        support += weight;
+      }
+      scratch[midi] = support > 0 ? energy / support : 0;
+    }
+
+    const smoothed = [];
+    let energyMax = 0;
+    let energySum = 0;
+    for (let midi = minMidi; midi <= maxMidi; midi++) {
+      const left = midi > minMidi ? scratch[midi - 1] : 0;
+      const center = scratch[midi];
+      const right = midi < maxMidi ? scratch[midi + 1] : 0;
+      const smoothedEnergy = 0.2 * left + 0.6 * center + 0.2 * right;
+      smoothed[midi] = smoothedEnergy;
+      energyMax = Math.max(energyMax, smoothedEnergy);
+      energySum += smoothedEnergy;
+    }
+
+    if (energyMax <= 1e-6) {
+      return [];
+    }
+
+    const threshold = Math.max(energyMax * (isLowEnd ? 0.28 : 0.22), energySum / Math.max((maxMidi - minMidi + 1) * 4, 1));
+    const candidates = [];
+
+    for (let midi = minMidi; midi <= maxMidi; midi++) {
+      const current = smoothed[midi] || 0;
+      const left = midi > minMidi ? smoothed[midi - 1] || 0 : 0;
+      const right = midi < maxMidi ? smoothed[midi + 1] || 0 : 0;
+      if (current < threshold || current < left || current < right) {
+        continue;
+      }
+
+      candidates.push({
+        sourceMidi: midi,
+        confidence: clamp(current / Math.max(energySum, 1e-6) * (isLowEnd ? 4 : 6), 0, 1),
+        energy: current,
+        bandwidth: isLowEnd ? 45 : 60,
+        isLowEnd,
+      });
+    }
+
+    candidates.sort((a, b) => b.energy - a.energy);
+    return candidates.slice(0, maxCandidates);
+  }
+
+  updateTrackedNotes(candidates) {
+    const matchedIds = new Set();
+    const activeNotes = this.trackedNotes.filter(note => note.missingFrames <= 4);
+
+    for (const candidate of candidates) {
+      let bestNote = null;
+      let bestDistance = Infinity;
+
+      for (const note of activeNotes) {
+        if (matchedIds.has(note.id) || note.isLowEnd !== candidate.isLowEnd) {
+          continue;
+        }
+        const distance = Math.abs(note.sourceMidi - candidate.sourceMidi);
+        if (distance < 1.75 && distance < bestDistance) {
+          bestNote = note;
+          bestDistance = distance;
+        }
+      }
+
+      if (!bestNote) {
+        this.trackedNotes.push(makeTrackedNote(this.nextTrackedNoteId++, candidate));
+        continue;
+      }
+
+      matchedIds.add(bestNote.id);
+      bestNote.sourceMidi += (candidate.sourceMidi - bestNote.sourceMidi) * 0.35;
+      bestNote.energy += (candidate.energy - bestNote.energy) * 0.28;
+      bestNote.confidence += (candidate.confidence - bestNote.confidence) * 0.35;
+      bestNote.bandwidth += (candidate.bandwidth - bestNote.bandwidth) * 0.3;
+      bestNote.age++;
+      bestNote.missingFrames = 0;
+    }
+
+    const keptNotes = [];
+    for (const note of this.trackedNotes) {
+      const wasMatched = matchedIds.has(note.id);
+      if (!wasMatched) {
+        note.missingFrames++;
+        note.energy *= 0.86;
+        note.confidence *= 0.82;
+      }
+      if (note.missingFrames <= 4 && note.confidence > 0.03 && note.energy > 1e-5) {
+        keptNotes.push(note);
+      }
+    }
+
+    keptNotes.sort((a, b) => b.energy - a.energy);
+    const tonalNotes = keptNotes.filter(note => !note.isLowEnd).slice(0, MAX_TRACKED_NOTES);
+    const lowNotes = keptNotes.filter(note => note.isLowEnd).slice(0, MAX_LOW_NOTES);
+    this.trackedNotes = [...tonalNotes, ...lowNotes];
+    this.assignTargets();
+  }
+
+  assignTargets() {
+    const occupiedPitchClasses = this.params.retuneCollapseDuplicates ? null : new Set();
+    const targetMask = this.params.retuneTargetMask;
+
+    for (const note of this.trackedNotes) {
+      const sourceRounded = Math.round(note.sourceMidi);
+      const sourcePitchClass = pitchClassForMidi(sourceRounded);
+      let targetMidi = sourceRounded;
+      let state = 'mapped';
+
+      if (targetMask[sourcePitchClass]) {
+        targetMidi = nearestMidiForPitchClass(note.sourceMidi, sourcePitchClass);
+      } else {
+        switch (this.params.retuneOutOfMaskMode) {
+          case 'preserve':
+            targetMidi = sourceRounded;
+            state = 'preserved';
+            break;
+          case 'mute':
+            targetMidi = sourceRounded;
+            state = 'muted';
+            break;
+          default: {
+            const nearest = findNearestAllowedMidi(note.sourceMidi, targetMask, occupiedPitchClasses);
+            if (nearest === null) {
+              targetMidi = sourceRounded;
+              state = 'preserved';
+            } else {
+              targetMidi = nearest;
+            }
+            break;
+          }
+        }
+      }
+
+      if (!this.params.retuneCollapseDuplicates && state === 'mapped') {
+        const targetPitchClass = pitchClassForMidi(targetMidi);
+        if (occupiedPitchClasses.has(targetPitchClass)) {
+          const alternate = findNearestAllowedMidi(note.sourceMidi, targetMask, occupiedPitchClasses);
+          if (alternate === null) {
+            state = 'preserved';
+            targetMidi = sourceRounded;
+          } else {
+            targetMidi = alternate;
+          }
+        }
+        if (state === 'mapped') {
+          occupiedPitchClasses.add(pitchClassForMidi(targetMidi));
+        }
+      }
+
+      note.targetMidi = targetMidi;
+      note.state = state;
+    }
+
+    this.trackedNotes.sort((a, b) => b.energy - a.energy);
+    this.noteCount = this.trackedNotes.length;
+    const strongest = this.trackedNotes[0];
+    this.detectedPitch = strongest ? midiToFreq(strongest.sourceMidi) : 0;
+    this.targetPitch = strongest ? midiToFreq(strongest.targetMidi) : 0;
+    this.targetRatio = strongest ? clamp(this.targetPitch / Math.max(this.detectedPitch, 1e-6), 0.25, 4) : 1;
+    this.smoothedRatio += (this.targetRatio - this.smoothedRatio) * 0.18;
+    this.confidence = strongest ? strongest.confidence : 0;
+    this.lowEndLocked = this.trackedNotes.some(note => note.isLowEnd && note.confidence > 0.18 && note.state !== 'muted');
+  }
+
+  analyzeTonalFrame() {
+    this.copyFrameFromRing(
+      this.tonalMonoRing,
+      this.tonalWritePos,
+      this.tonalRingMask,
+      this.tonalFrameSize,
+      this.tonalMonoReal,
+    );
+
+    let frameEnergy = 0;
+    for (let i = 0; i < this.tonalFrameSize; i++) {
+      const sample = this.tonalMonoReal[i] * this.tonalWindow[i];
+      this.tonalMonoReal[i] = sample;
+      this.tonalMonoImag[i] = 0;
+      frameEnergy += sample * sample;
+    }
+
+    this.tonalFFT.transform(this.tonalMonoReal, this.tonalMonoImag, false);
+    for (let bin = 0; bin < this.tonalMagnitudes.length; bin++) {
+      this.tonalMagnitudes[bin] = Math.hypot(this.tonalMonoReal[bin], this.tonalMonoImag[bin]);
+    }
+
+    let flux = 0;
+    let previousTotal = 0;
+    for (let bin = 1; bin < this.tonalMagnitudes.length; bin++) {
+      const current = this.tonalMagnitudes[bin];
+      const previous = this.prevTonalMagnitudes[bin];
+      if (current > previous) {
+        flux += current - previous;
+      }
+      previousTotal += previous;
+      this.prevTonalMagnitudes[bin] = current;
+    }
+
+    const fluxRatio = flux / Math.max(previousTotal, 1e-6);
+    this.transientBypassActive = this.params.retunePreserveTransients && fluxRatio > 0.55;
+    this.transientMix = this.transientBypassActive ? 0.35 : 1.0;
+    this.detectorEnv += (Math.sqrt(frameEnergy / this.tonalFrameSize) - this.detectorEnv) * 0.18;
+
+    const tonalCandidates = this.detectCandidatesFromSpectrum(this.tonalMagnitudes, this.tonalFrameSize, {
+      minMidi: 40,
+      maxMidi: 96,
+      maxHarmonics: 8,
+      maxCandidates: MAX_TRACKED_NOTES,
+      lowCutoffHz: 5000,
+      isLowEnd: false,
+    });
+    this.updateTrackedNotes(tonalCandidates);
+  }
+
+  analyzeLowFrame() {
+    this.copyFrameFromRing(
+      this.lowMonoRing,
+      this.lowWritePos,
+      this.lowMonoRingMask,
+      this.lowFrameSize,
+      this.lowReal,
+    );
+
+    for (let i = 0; i < this.lowFrameSize; i++) {
+      this.lowReal[i] *= this.lowWindow[i];
+      this.lowImag[i] = 0;
+    }
+
+    this.lowFFT.transform(this.lowReal, this.lowImag, false);
+    for (let bin = 0; bin < this.lowMagnitudes.length; bin++) {
+      this.lowMagnitudes[bin] = Math.hypot(this.lowReal[bin], this.lowImag[bin]);
+    }
+
+    const lowCandidates = this.detectCandidatesFromSpectrum(this.lowMagnitudes, this.lowFrameSize, {
+      minMidi: 28,
+      maxMidi: 52,
+      maxHarmonics: 6,
+      maxCandidates: MAX_LOW_NOTES,
+      lowCutoffHz: 320,
+      isLowEnd: true,
+    });
+    this.updateTrackedNotes(lowCandidates);
+  }
+
+  getActiveTonalNotes() {
+    return this.trackedNotes.filter(
+      note => !note.isLowEnd && note.missingFrames <= 2 && note.confidence > 0.08 && note.energy > 1e-5,
+    );
+  }
+
+  applySpectralRetune(real, imag) {
+    const activeNotes = this.getActiveTonalNotes();
+    const halfBins = this.tonalMagnitudes.length;
+    const strengthBase = clamp(this.params.retuneStrength * this.transientMix, 0, 1);
+    const textureScalar = 1 - this.params.retuneTextureAmount * 0.45;
+    const binHz = this.sampleRate / this.tonalFrameSize;
+
+    this.tonalTargetReal.fill(0);
+    this.tonalTargetImag.fill(0);
+
+    for (let bin = 1; bin < halfBins - 1; bin++) {
+      const sourceReal = real[bin];
+      const sourceImag = imag[bin];
+      const sourceMagnitude = Math.hypot(sourceReal, sourceImag);
+      if (sourceMagnitude < 1e-6) {
+        continue;
+      }
+
+      const frequency = bin * binHz;
+      let bestNote = null;
+      let bestScore = 0;
+
+      for (const note of activeNotes) {
+        const sourceFreq = midiToFreq(note.sourceMidi);
+        for (let harmonic = 1; harmonic <= 8; harmonic++) {
+          const harmonicFreq = sourceFreq * harmonic;
+          if (harmonicFreq >= this.sampleRate * 0.48 || harmonicFreq > 5000) {
+            break;
+          }
+
+          const width = note.bandwidth + harmonic * 8;
+          const centsOff = Math.abs(centsBetween(frequency, harmonicFreq));
+          if (centsOff > width) {
+            continue;
+          }
+
+          const score = note.energy * note.confidence * (1 - centsOff / width) / Math.pow(harmonic, 0.72);
+          if (score > bestScore) {
+            bestScore = score;
+            bestNote = note;
+          }
+        }
+      }
+
+      if (!bestNote || bestScore < 0.01) {
+        this.tonalTargetReal[bin] += sourceReal;
+        this.tonalTargetImag[bin] += sourceImag;
+        continue;
+      }
+
+      if (bestNote.state === 'muted') {
+        continue;
+      }
+
+      if (bestNote.state === 'preserved') {
+        this.tonalTargetReal[bin] += sourceReal;
+        this.tonalTargetImag[bin] += sourceImag;
+        continue;
+      }
+
+      const sourceFreq = midiToFreq(bestNote.sourceMidi);
+      const targetFreq = midiToFreq(bestNote.targetMidi);
+      const ratio = targetFreq / Math.max(sourceFreq, 1e-6);
+      const moveAmount = clamp(strengthBase * textureScalar * Math.min(1, bestScore * 1.5), 0, 1);
+      const stayAmount = 1 - moveAmount;
+
+      this.tonalTargetReal[bin] += sourceReal * stayAmount;
+      this.tonalTargetImag[bin] += sourceImag * stayAmount;
+
+      const targetBin = clamp(bin * ratio, 1, halfBins - 2);
+      const baseIndex = Math.floor(targetBin);
+      const frac = targetBin - baseIndex;
+      const movedReal = sourceReal * moveAmount;
+      const movedImag = sourceImag * moveAmount;
+
+      this.tonalTargetReal[baseIndex] += movedReal * (1 - frac);
+      this.tonalTargetImag[baseIndex] += movedImag * (1 - frac);
+      this.tonalTargetReal[baseIndex + 1] += movedReal * frac;
+      this.tonalTargetImag[baseIndex + 1] += movedImag * frac;
+    }
+
+    real[0] = 0;
+    imag[0] = 0;
+    for (let bin = 1; bin < halfBins - 1; bin++) {
+      real[bin] = this.tonalTargetReal[bin];
+      imag[bin] = this.tonalTargetImag[bin];
+      const mirror = this.tonalFrameSize - bin;
+      real[mirror] = real[bin];
+      imag[mirror] = -imag[bin];
+    }
+    real[halfBins - 1] = this.tonalTargetReal[halfBins - 1];
+    imag[halfBins - 1] = 0;
+  }
+
+  renderTonalFrame(numChannels) {
+    const frameStart = this.tonalInputSampleCount - this.tonalFrameSize;
+    const synthStart = frameStart + this.latencySamples;
+
+    for (let ch = 0; ch < numChannels; ch++) {
+      const frame = this.blockInputScratch[ch];
+      this.copyFrameFromRing(
+        this.tonalInputRings[ch],
+        this.tonalWritePos,
+        this.tonalRingMask,
+        this.tonalFrameSize,
+        frame,
+      );
+
+      for (let i = 0; i < this.tonalFrameSize; i++) {
+        this.tonalWorkReal[i] = frame[i] * this.tonalWindow[i];
+        this.tonalWorkImag[i] = 0;
+      }
+
+      this.tonalFFT.transform(this.tonalWorkReal, this.tonalWorkImag, false);
+      this.applySpectralRetune(this.tonalWorkReal, this.tonalWorkImag);
+      this.tonalFFT.transform(this.tonalWorkReal, this.tonalWorkImag, true);
+
+      const outputRing = this.outputRings[ch];
+      for (let i = 0; i < this.tonalFrameSize; i++) {
+        const sample = this.tonalWorkReal[i] * this.tonalSynthesisWindow[i];
+        const outputIndex = (synthStart + i) & this.outputRingMask;
+        outputRing[outputIndex] += sample;
+      }
+    }
+  }
+
+  renderLowResynthSample() {
+    const lowNotes = this.trackedNotes.filter(
+      note => note.isLowEnd && note.missingFrames <= 2 && note.confidence > 0.1 && note.state !== 'muted',
+    );
+    if (lowNotes.length === 0) {
+      return 0;
+    }
+
+    const totalEnergy = lowNotes.reduce((sum, note) => sum + note.energy, 0);
+    let sample = 0;
+    let strongestTarget = 0;
+    let strongestWeight = 0;
+
+    for (const note of lowNotes) {
+      const targetMidi = note.state === 'mapped' ? note.targetMidi : note.sourceMidi;
+      const targetFreq = midiToFreq(targetMidi);
+      const weight = clamp(note.energy / Math.max(totalEnergy, 1e-6), 0, 1) * note.confidence;
+      if (weight > strongestWeight) {
+        strongestWeight = weight;
+        strongestTarget = targetFreq;
+      }
+
+      const harmonicWeights = [1.0, 0.45, 0.18];
+      for (let harmonic = 0; harmonic < harmonicWeights.length; harmonic++) {
+        const frequency = targetFreq * (harmonic + 1);
+        note.phases[harmonic] += TWO_PI * frequency / this.sampleRate;
+        if (note.phases[harmonic] > TWO_PI) {
+          note.phases[harmonic] -= TWO_PI;
+        }
+        sample += Math.sin(note.phases[harmonic]) * harmonicWeights[harmonic] * weight;
+      }
+    }
+
+    if (this.params.retuneSubReinforcement > 0 && strongestTarget > 0) {
+      this.subPhase = (this.subPhase || 0) + TWO_PI * strongestTarget / this.sampleRate;
+      if (this.subPhase > TWO_PI) {
+        this.subPhase -= TWO_PI;
+      }
+      sample += Math.sin(this.subPhase) * this.params.retuneSubReinforcement * strongestWeight;
+    }
+
+    return sample * 0.35;
+  }
+
+  processBlock(inputBlock, numChannels, length, mix = { lowGain: 1, highGain: 1 }) {
+    this.ensureBlockSize(length);
+
+    if (!this.params.retuneEnabled) {
+      for (let ch = 0; ch < numChannels; ch++) {
+        this.blockOutputScratch[ch].set(inputBlock[ch].subarray(0, length));
+      }
+      return this.blockOutputScratch;
+    }
+
+    for (let sampleIndex = 0; sampleIndex < length; sampleIndex++) {
+      let monoTonal = 0;
+      let monoLow = 0;
+
+      for (let ch = 0; ch < numChannels; ch++) {
+        const split = this.splitSample(inputBlock[ch][sampleIndex], ch);
+        this.tonalInputRings[ch][this.tonalWritePos] = split.tonal;
+        this.airDelayRings[ch][this.delayWritePos] = split.air;
+        monoTonal += split.tonal;
+        monoLow += split.lowSeed;
+      }
+
+      this.tonalMonoRing[this.tonalWritePos] = monoTonal / Math.max(numChannels, 1);
+      this.lowMonoRing[this.lowWritePos] = monoLow / Math.max(numChannels, 1);
+
+      this.tonalWritePos = (this.tonalWritePos + 1) & this.tonalRingMask;
+      this.lowWritePos = (this.lowWritePos + 1) & this.lowMonoRingMask;
+      this.tonalInputSampleCount++;
+      this.lowSampleCount++;
+      this.tonalSamplesSinceFrame++;
+      this.lowSamplesSinceFrame++;
+
+      if (this.tonalInputSampleCount >= this.tonalFrameSize && this.tonalSamplesSinceFrame >= this.tonalHopSize) {
+        this.tonalSamplesSinceFrame -= this.tonalHopSize;
+        this.analyzeTonalFrame();
+        this.renderTonalFrame(numChannels);
+      }
+
+      if (this.lowSampleCount >= this.lowFrameSize && this.lowSamplesSinceFrame >= this.lowHopSize) {
+        this.lowSamplesSinceFrame -= this.lowHopSize;
+        this.analyzeLowFrame();
+      }
+
+      const lowResynth = this.renderLowResynthSample();
+
+      for (let ch = 0; ch < numChannels; ch++) {
+        const outputIndex = this.outputSampleCount & this.outputRingMask;
+        const airReadIndex = (this.delayWritePos - this.latencySamples + this.delayRingSize) & this.delayRingMask;
+        const tonalSample = this.outputRings[ch][outputIndex];
+        this.outputRings[ch][outputIndex] = 0;
+
+        const delayedAir = this.airDelayRings[ch][airReadIndex];
+        const lowRetuned = this.onePoleLowpass(tonalSample, 180, this.lowBlendState, ch);
+        const midHighRetuned = tonalSample - lowRetuned;
+        const lowBlend = this.params.retuneLowEndMode === 'hybrid' ? this.params.retuneLowEndBlend : 0;
+        const hybridLow = lowRetuned * (1 - lowBlend) + lowResynth * lowBlend * mix.lowGain;
+        this.blockOutputScratch[ch][sampleIndex] = midHighRetuned + hybridLow + delayedAir * this.params.retuneAirMix * mix.highGain;
+      }
+
+      this.outputSampleCount++;
+      this.delayWritePos = (this.delayWritePos + 1) & this.delayRingMask;
+    }
+
+    return this.blockOutputScratch;
+  }
+
+  getStatus() {
+    const notes = this.trackedNotes.map(note => ({
+      sourceMidi: note.sourceMidi,
+      targetMidi: note.targetMidi,
+      confidence: note.confidence,
+      energy: note.energy,
+      bandwidth: note.bandwidth,
+      isLowEnd: note.isLowEnd,
+      state: note.state,
+    }));
+
+    return {
+      backendName: 'Polyphonic Retune Core',
+      retuneEnabled: this.params.retuneEnabled,
+      voiced: this.confidence > 0.08,
+      detectedPitch: this.detectedPitch,
+      targetPitch: this.targetPitch,
+      targetRatio: this.targetRatio,
+      smoothedRatio: this.smoothedRatio,
+      confidence: this.confidence,
+      detectorEnv: this.detectorEnv,
+      lowEndStrategy: this.params.retuneLowEndMode === 'hybrid'
+        ? 'Tracked Low End + Hybrid Resynth'
+        : 'Tracked Low End',
+      notes,
+      lowEndLocked: this.lowEndLocked,
+      transientBypassActive: this.transientBypassActive,
+      analysisLatencyMs: this.analysisLatencyMs,
+      overloaded: this.overloaded,
+      noteCount: notes.length,
+    };
+  }
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -512,6 +512,10 @@ export default function App() {
         <SpectrumAnalyzer
           analyser={engine?.getAnalyser() ?? null}
           eqBands={params.eqBands}
+          retuneStatus={retuneStatus}
+          retuneEnabled={params.retuneEnabled}
+          retuneKey={params.retuneKey}
+          retuneScale={params.retuneScale}
           onBandChange={handleBandChange}
           width={specWidth}
           height={specHeight}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,9 +5,13 @@ import { SpectrumAnalyzer } from './components/SpectrumAnalyzer';
 import { EffectModule } from './components/EffectModule';
 import { Knob } from './components/Knob';
 import { AddFxButton } from './components/AddFxButton';
+import { RetuneModule } from './components/RetuneModule';
 import { useAudioEngine } from './hooks/useAudioEngine';
 import { FX_CATALOG } from './audio/engine';
 import type { EQBand, FilterType, FxSlot, FxType, EngineParams, PeqInstance } from './audio/engine';
+
+const FX_ORDER: FxType[] = ['peq', 'saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2'];
+const SINGLETON_FX: FxType[] = ['saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2'];
 
 // Electron API type
 declare global {
@@ -86,6 +90,7 @@ export default function App() {
     duration,
     currentTime,
     params,
+    retuneStatus,
     init,
     loadFile,
     togglePlay,
@@ -101,14 +106,17 @@ export default function App() {
   const [selectedBand, setSelectedBand] = useState<number | null>(null);
   const [showDevPanel, setShowDevPanel] = useState(false);
 
-  // --- Dynamic FX slots (default: Saturate → Quantize → Saturate 2) ---
+  // --- Dynamic FX slots (default: Saturate → Retune → Saturate 2) ---
   const [fxSlots, setFxSlots] = useState<FxSlot[]>([
     { id: crypto.randomUUID(), type: 'saturate' },
-    { id: crypto.randomUUID(), type: 'quantize' },
+    { id: crypto.randomUUID(), type: 'retune' },
     { id: crypto.randomUUID(), type: 'saturate2' },
   ]);
 
   const addFxSlot = useCallback((type: FxType) => {
+    if (SINGLETON_FX.includes(type) && fxSlots.some(slot => slot.type === type)) {
+      return;
+    }
     const newId = crypto.randomUUID();
     setFxSlots(prev => [...prev, { id: newId, type }]);
     if (type === 'peq') {
@@ -117,21 +125,57 @@ export default function App() {
           id: newId,
           enabled: true,
           mode: 'cut',
-          key: params.quantizeKey,
-          scale: params.quantizeScale,
+          key: params.retuneKey,
+          scale: params.retuneScale,
           amount: 0.5,
           q: 5.0,
         }],
       });
     }
-  }, [params.peqInstances, params.quantizeKey, params.quantizeScale, updateParams]);
+  }, [fxSlots, params.peqInstances, params.retuneKey, params.retuneScale, updateParams]);
 
   const removeFxSlot = useCallback((id: string) => {
+    const slot = fxSlots.find(s => s.id === id);
+    if (!slot) return;
+
     setFxSlots(prev => prev.filter(s => s.id !== id));
-    updateParams({
-      peqInstances: params.peqInstances.filter(inst => inst.id !== id),
-    });
-  }, [params.peqInstances, updateParams]);
+
+    if (slot.type === 'peq') {
+      updateParams({
+        peqInstances: params.peqInstances.filter(inst => inst.id !== id),
+      });
+      return;
+    }
+
+    switch (slot.type) {
+      case 'saturate':
+        updateParams({ saturateEnabled: false });
+        break;
+      case 'retune':
+        updateParams({ retuneEnabled: false });
+        break;
+      case 'delay':
+        updateParams({ delayEnabled: false });
+        break;
+      case 'modulate':
+        updateParams({ modEnabled: false });
+        break;
+      case 'lofi':
+        updateParams({ lofiEnabled: false });
+        break;
+      case 'saturate2':
+        updateParams({ saturate2Enabled: false });
+        break;
+    }
+  }, [fxSlots, params.peqInstances, updateParams]);
+
+  const orderedFxSlots = [...fxSlots].sort(
+    (a, b) => FX_ORDER.indexOf(a.type) - FX_ORDER.indexOf(b.type)
+  );
+
+  const availableFxTypes = (Object.keys(FX_CATALOG) as FxType[]).filter((type) => (
+    type === 'peq' || !orderedFxSlots.some((slot) => slot.type === type)
+  ));
 
   // --- Keyboard shortcuts ---
   useEffect(() => {
@@ -276,111 +320,17 @@ export default function App() {
           </EffectModule>
         );
 
-      case 'quantize':
-        {
-        const noteNames = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
-        const scaleIntervals: Record<string, number[]> = {
-          major: [0, 2, 4, 5, 7, 9, 11],
-          minor: [0, 2, 3, 5, 7, 8, 10],
-          pentatonic: [0, 2, 4, 7, 9],
-          dorian: [0, 2, 3, 5, 7, 9, 10],
-          mixolydian: [0, 2, 4, 5, 7, 9, 10],
-          harmonic_minor: [0, 2, 3, 5, 7, 8, 11],
-        };
-        const currentScale = scaleIntervals[params.quantizeScale] ?? scaleIntervals.major;
-        const scaleNoteCount = currentScale.length;
-        const subSources = ['root', 'manual', 'scale_degree'] as const;
-        const subSourceIndex = subSources.indexOf(params.quantizeSubSource);
-        const scaleDegreeMax = Math.max(0, scaleNoteCount - 1);
-        const subDegreeDisplay = `Deg ${Math.round(params.quantizeSubDegree) + 1}`;
-        // For manual mode: show the actual note name from the scale
-        const manualNoteIndex = Math.max(0, Math.min(scaleDegreeMax, Math.round(params.quantizeSubNote)));
-        const manualNoteName = noteNames[(params.quantizeKey + currentScale[manualNoteIndex]) % 12];
+      case 'retune':
         return (
-          <EffectModule
+          <RetuneModule
             key={slot.id}
-            title={meta.label}
             color={meta.color}
-            enabled={params.quantizeEnabled}
-            onToggle={() => updateParams({ quantizeEnabled: !params.quantizeEnabled })}
+            params={params}
+            status={retuneStatus}
+            updateParams={updateParams}
             onRemove={() => removeFxSlot(slot.id)}
-            subtitle={params.quantizeScale}
-            subtitleOptions={['major', 'minor', 'pentatonic', 'dorian', 'mixolydian', 'harmonic_minor']}
-            onSubtitleChange={(v) => updateParams({ quantizeScale: v })}
-          >
-            <Knob
-              label="Strength"
-              value={params.quantizeStrength}
-              onChange={(v) => updateParams({ quantizeStrength: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.quantizeStrength * 100)}%`}
-            />
-            <Knob
-              label="Sub"
-              value={params.quantizeSubEnabled ? 1 : 0}
-              onChange={(v) => updateParams({ quantizeSubEnabled: Math.round(v) >= 1 })}
-              color={meta.color}
-              min={0}
-              max={1}
-              displayValue={params.quantizeSubEnabled ? 'On' : 'Off'}
-            />
-            <Knob
-              label="Key"
-              value={params.quantizeKey}
-              onChange={(v) => updateParams({ quantizeKey: Math.round(v) })}
-              color={meta.color}
-              min={0}
-              max={11}
-              displayValue={noteNames[Math.round(params.quantizeKey)]}
-            />
-            <Knob
-              label="Sub Src"
-              value={subSourceIndex < 0 ? 0 : subSourceIndex}
-              onChange={(v) => updateParams({ quantizeSubSource: subSources[Math.max(0, Math.min(subSources.length - 1, Math.round(v)))] })}
-              color={meta.color}
-              min={0}
-              max={2}
-              displayValue={params.quantizeSubSource === 'scale_degree' ? 'Degree' : params.quantizeSubSource}
-            />
-            <Knob
-              label={params.quantizeSubSource === 'scale_degree' ? 'Degree' : 'Sub Note'}
-              value={params.quantizeSubSource === 'scale_degree' ? params.quantizeSubDegree : params.quantizeSubNote}
-              onChange={(v) => (
-                params.quantizeSubSource === 'scale_degree'
-                  ? updateParams({ quantizeSubDegree: Math.round(v) })
-                  : updateParams({ quantizeSubNote: Math.round(v) })
-              )}
-              color={meta.color}
-              min={0}
-              max={scaleDegreeMax}
-              displayValue={params.quantizeSubSource === 'scale_degree' ? subDegreeDisplay : manualNoteName}
-            />
-            <Knob
-              label="Sub Oct"
-              value={params.quantizeSubOctave}
-              onChange={(v) => updateParams({ quantizeSubOctave: Math.round(v) })}
-              color={meta.color}
-              min={0}
-              max={4}
-              displayValue={`Oct ${Math.round(params.quantizeSubOctave)}`}
-            />
-            <Knob
-              label="Sub Lvl"
-              value={params.quantizeSubLevel}
-              onChange={(v) => updateParams({ quantizeSubLevel: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.quantizeSubLevel * 100)}%`}
-            />
-            <Knob
-              label="Air"
-              value={params.quantizeAirMix}
-              onChange={(v) => updateParams({ quantizeAirMix: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.quantizeAirMix * 100)}%`}
-            />
-          </EffectModule>
+          />
         );
-        }
 
       case 'delay':
         return (
@@ -601,8 +551,8 @@ export default function App() {
 
       {/* Effect Modules Row */}
       <div className="flex gap-2 px-2 py-3 overflow-x-auto items-start">
-        {fxSlots.map(slot => renderFxSlot(slot))}
-        <AddFxButton onAdd={addFxSlot} />
+        {orderedFxSlots.map(slot => renderFxSlot(slot))}
+        <AddFxButton onAdd={addFxSlot} availableTypes={availableFxTypes} />
         <OutputModule params={params} updateParams={updateParams} />
       </div>
     </div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,8 +10,8 @@ import { useAudioEngine } from './hooks/useAudioEngine';
 import { FX_CATALOG } from './audio/engine';
 import type { EQBand, FilterType, FxSlot, FxType, EngineParams, PeqInstance } from './audio/engine';
 
-const FX_ORDER: FxType[] = ['peq', 'saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2'];
-const SINGLETON_FX: FxType[] = ['saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2'];
+const FX_ORDER: FxType[] = ['peq', 'saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2', 'sub'];
+const SINGLETON_FX: FxType[] = ['saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2', 'sub'];
 
 // Electron API type
 declare global {
@@ -111,6 +111,7 @@ export default function App() {
     { id: crypto.randomUUID(), type: 'saturate' },
     { id: crypto.randomUUID(), type: 'retune' },
     { id: crypto.randomUUID(), type: 'saturate2' },
+    { id: crypto.randomUUID(), type: 'sub' },
   ]);
 
   const addFxSlot = useCallback((type: FxType) => {
@@ -165,6 +166,9 @@ export default function App() {
         break;
       case 'saturate2':
         updateParams({ saturate2Enabled: false });
+        break;
+      case 'sub':
+        updateParams({ subEnabled: false });
         break;
     }
   }, [fxSlots, params.peqInstances, updateParams]);
@@ -316,6 +320,27 @@ export default function App() {
               onChange={(v) => updateParams({ saturate2Tilt: v })}
               color={meta.color}
               displayValue={`${((params.saturate2Tilt - 0.5) * 100).toFixed(0)}`}
+            />
+          </EffectModule>
+        );
+
+      case 'sub':
+        return (
+          <EffectModule
+            key={slot.id}
+            title={meta.label}
+            color={meta.color}
+            enabled={params.subEnabled}
+            onToggle={() => updateParams({ subEnabled: !params.subEnabled })}
+            onRemove={() => removeFxSlot(slot.id)}
+            subtitle={retuneStatus?.lowEndLocked ? 'Locked' : 'Waiting'}
+          >
+            <Knob
+              label="Level"
+              value={params.subLevel}
+              onChange={(v) => updateParams({ subLevel: v })}
+              color={meta.color}
+              displayValue={`${Math.round(params.subLevel * 100)}%`}
             />
           </EffectModule>
         );

--- a/ui/src/audio/engine.ts
+++ b/ui/src/audio/engine.ts
@@ -85,7 +85,10 @@ export interface EngineParams {
   retuneMode: RetuneMode;
   retuneKey: number;
   retuneScale: RetuneScale;
+  retuneUseCustomMask: boolean;
   retuneStrength: number;
+  retuneDeadbandCents: number;
+  retuneConfidenceGate: number;
   retuneTargetMask: boolean[];
   retuneOutOfMaskMode: RetuneOutOfMaskMode;
   retunePreserveTransients: boolean;
@@ -138,7 +141,10 @@ export const DEFAULT_PARAMS: EngineParams = {
   retuneMode: 'polyphonic',
   retuneKey: 0,
   retuneScale: 'major',
+  retuneUseCustomMask: false,
   retuneStrength: 0.7,
+  retuneDeadbandCents: 18,
+  retuneConfidenceGate: 0.22,
   retuneTargetMask: buildScaleMask(0, 'major'),
   retuneOutOfMaskMode: 'nearest',
   retunePreserveTransients: true,

--- a/ui/src/audio/engine.ts
+++ b/ui/src/audio/engine.ts
@@ -2,6 +2,15 @@
  * Audio Engine - manages the Web Audio graph and AudioWorklet
  */
 
+import type {
+  RetuneLowEndMode,
+  RetuneMode,
+  RetuneOutOfMaskMode,
+  RetuneScale,
+  RetuneTrackedNote,
+} from './retune';
+import { buildScaleMask } from './retune';
+
 export type FilterType = 'peak' | 'lowshelf' | 'highshelf' | 'lowpass' | 'highpass';
 
 export interface EQBand {
@@ -11,7 +20,7 @@ export interface EQBand {
   type: FilterType;
 }
 
-export type FxType = 'saturate' | 'quantize' | 'delay' | 'modulate' | 'lofi' | 'saturate2' | 'peq';
+export type FxType = 'saturate' | 'retune' | 'delay' | 'modulate' | 'lofi' | 'saturate2' | 'peq';
 
 export interface PeqInstance {
   id: string;
@@ -28,9 +37,28 @@ export interface FxSlot {
   type: FxType;
 }
 
+export interface RetuneStatus {
+  backendName: string;
+  retuneEnabled: boolean;
+  voiced: boolean;
+  detectedPitch: number;
+  targetPitch: number;
+  targetRatio: number;
+  smoothedRatio: number;
+  confidence: number;
+  detectorEnv: number;
+  lowEndStrategy: string;
+  notes: RetuneTrackedNote[];
+  lowEndLocked: boolean;
+  transientBypassActive: boolean;
+  analysisLatencyMs: number;
+  overloaded: boolean;
+  noteCount: number;
+}
+
 export const FX_CATALOG: Record<FxType, { label: string; color: string }> = {
   saturate:  { label: 'Saturate',   color: '#c45e3e' },
-  quantize:  { label: 'Quantize',   color: '#4ec48a' },
+  retune:    { label: 'Retune',     color: '#4ec48a' },
   delay:     { label: 'Delay',      color: '#3eafc4' },
   modulate:  { label: 'Modulate',   color: '#8a5ec4' },
   lofi:      { label: 'Lo-Fi',      color: '#8a7e5e' },
@@ -53,17 +81,20 @@ export interface EngineParams {
   saturate2Drive: number;
   saturate2Tilt: number;
 
-  quantizeEnabled: boolean;
-  quantizeKey: number;
-  quantizeScale: string;
-  quantizeStrength: number;
-  quantizeSubEnabled: boolean;
-  quantizeSubSource: 'root' | 'manual' | 'scale_degree';
-  quantizeSubNote: number;
-  quantizeSubDegree: number;
-  quantizeSubOctave: number;
-  quantizeSubLevel: number;
-  quantizeAirMix: number;
+  retuneEnabled: boolean;
+  retuneMode: RetuneMode;
+  retuneKey: number;
+  retuneScale: RetuneScale;
+  retuneStrength: number;
+  retuneTargetMask: boolean[];
+  retuneOutOfMaskMode: RetuneOutOfMaskMode;
+  retunePreserveTransients: boolean;
+  retuneTextureAmount: number;
+  retuneLowEndMode: RetuneLowEndMode;
+  retuneLowEndBlend: number;
+  retuneCollapseDuplicates: boolean;
+  retuneSubReinforcement: number;
+  retuneAirMix: number;
 
   lowGain: number;
   highGain: number;
@@ -103,17 +134,20 @@ export const DEFAULT_PARAMS: EngineParams = {
   saturate2Drive: 0.5,
   saturate2Tilt: 0.5,
 
-  quantizeEnabled: false,
-  quantizeKey: 0,
-  quantizeScale: 'major',
-  quantizeStrength: 0.7,
-  quantizeSubEnabled: true,
-  quantizeSubSource: 'root',
-  quantizeSubNote: 0,
-  quantizeSubDegree: 0,
-  quantizeSubOctave: 2,
-  quantizeSubLevel: 0.35,
-  quantizeAirMix: 1.0,
+  retuneEnabled: false,
+  retuneMode: 'polyphonic',
+  retuneKey: 0,
+  retuneScale: 'major',
+  retuneStrength: 0.7,
+  retuneTargetMask: buildScaleMask(0, 'major'),
+  retuneOutOfMaskMode: 'nearest',
+  retunePreserveTransients: true,
+  retuneTextureAmount: 0.2,
+  retuneLowEndMode: 'hybrid',
+  retuneLowEndBlend: 0.55,
+  retuneCollapseDuplicates: false,
+  retuneSubReinforcement: 0.25,
+  retuneAirMix: 1.0,
 
   lowGain: 1.0,
   highGain: 1.0,
@@ -145,6 +179,7 @@ export const DEFAULT_PARAMS: EngineParams = {
 };
 
 export type AnalysisCallback = (samples: Float32Array) => void;
+export type RetuneStatusCallback = (status: RetuneStatus) => void;
 
 export class AudioEngine {
   private ctx: AudioContext | null = null;
@@ -154,6 +189,7 @@ export class AudioEngine {
   private audioBuffer: AudioBuffer | null = null;
   private isPlaying = false;
   private onAnalysis: AnalysisCallback | null = null;
+  private onRetuneStatus: RetuneStatusCallback | null = null;
   private startTime = 0;
   private startOffset = 0;
 
@@ -177,12 +213,18 @@ export class AudioEngine {
     this.workletNode.port.onmessage = (e) => {
       if (e.data.type === 'analysis' && this.onAnalysis) {
         this.onAnalysis(e.data.samples);
+      } else if (e.data.type === 'retune-status' && this.onRetuneStatus) {
+        this.onRetuneStatus(e.data.status as RetuneStatus);
       }
     };
   }
 
   setAnalysisCallback(cb: AnalysisCallback) {
     this.onAnalysis = cb;
+  }
+
+  setRetuneStatusCallback(cb: RetuneStatusCallback) {
+    this.onRetuneStatus = cb;
   }
 
   getAnalyser(): AnalyserNode | null {

--- a/ui/src/audio/engine.ts
+++ b/ui/src/audio/engine.ts
@@ -20,7 +20,7 @@ export interface EQBand {
   type: FilterType;
 }
 
-export type FxType = 'saturate' | 'retune' | 'delay' | 'modulate' | 'lofi' | 'saturate2' | 'peq';
+export type FxType = 'saturate' | 'retune' | 'delay' | 'modulate' | 'lofi' | 'saturate2' | 'sub' | 'peq';
 
 export interface PeqInstance {
   id: string;
@@ -63,6 +63,7 @@ export const FX_CATALOG: Record<FxType, { label: string; color: string }> = {
   modulate:  { label: 'Modulate',   color: '#8a5ec4' },
   lofi:      { label: 'Lo-Fi',      color: '#8a7e5e' },
   saturate2: { label: 'Saturate 2', color: '#d47a5e' },
+  sub:       { label: 'Sub',        color: '#6ea8ff' },
   peq:       { label: 'Param EQ',   color: '#5ec4b8' },
 };
 
@@ -96,8 +97,10 @@ export interface EngineParams {
   retuneLowEndMode: RetuneLowEndMode;
   retuneLowEndBlend: number;
   retuneCollapseDuplicates: boolean;
-  retuneSubReinforcement: number;
   retuneAirMix: number;
+
+  subEnabled: boolean;
+  subLevel: number;
 
   lowGain: number;
   highGain: number;
@@ -152,8 +155,10 @@ export const DEFAULT_PARAMS: EngineParams = {
   retuneLowEndMode: 'hybrid',
   retuneLowEndBlend: 0.55,
   retuneCollapseDuplicates: false,
-  retuneSubReinforcement: 0.25,
   retuneAirMix: 1.0,
+
+  subEnabled: true,
+  subLevel: 0.25,
 
   lowGain: 1.0,
   highGain: 1.0,

--- a/ui/src/audio/retune.ts
+++ b/ui/src/audio/retune.ts
@@ -1,0 +1,53 @@
+export const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const;
+
+export const RETUNE_SCALES = {
+  major: [0, 2, 4, 5, 7, 9, 11],
+  minor: [0, 2, 3, 5, 7, 8, 10],
+  pentatonic: [0, 2, 4, 7, 9],
+  dorian: [0, 2, 3, 5, 7, 9, 10],
+  mixolydian: [0, 2, 4, 5, 7, 9, 10],
+  harmonic_minor: [0, 2, 3, 5, 7, 8, 11],
+  chromatic: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+} as const;
+
+export type RetuneScale = keyof typeof RETUNE_SCALES;
+export type RetuneOutOfMaskMode = 'nearest' | 'preserve' | 'mute';
+export type RetuneLowEndMode = 'hybrid';
+export type RetuneMode = 'polyphonic';
+export type RetuneNoteState = 'mapped' | 'preserved' | 'muted';
+
+export interface RetuneTrackedNote {
+  sourceMidi: number;
+  targetMidi: number;
+  confidence: number;
+  energy: number;
+  bandwidth: number;
+  isLowEnd: boolean;
+  state: RetuneNoteState;
+}
+
+export function buildScaleMask(key: number, scale: RetuneScale): boolean[] {
+  const mask = new Array(12).fill(false);
+  const intervals = RETUNE_SCALES[scale] ?? RETUNE_SCALES.major;
+  for (const interval of intervals) {
+    mask[(key + interval + 12) % 12] = true;
+  }
+  return mask;
+}
+
+export function formatMidiNote(midi: number): string {
+  if (!Number.isFinite(midi)) return '—';
+  const rounded = Math.round(midi);
+  const note = NOTE_NAMES[((rounded % 12) + 12) % 12];
+  const octave = Math.floor(rounded / 12) - 1;
+  return `${note}${octave}`;
+}
+
+export function midiToFreq(midi: number): number {
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+export function freqToMidi(freq: number): number {
+  if (!Number.isFinite(freq) || freq <= 0) return Number.NEGATIVE_INFINITY;
+  return 69 + 12 * Math.log2(freq / 440);
+}

--- a/ui/src/components/AddFxButton.tsx
+++ b/ui/src/components/AddFxButton.tsx
@@ -4,13 +4,15 @@ import type { FxType } from '../audio/engine';
 
 interface AddFxButtonProps {
   onAdd: (type: FxType) => void;
+  availableTypes: FxType[];
 }
 
 const FX_TYPES = Object.keys(FX_CATALOG) as FxType[];
 
-export function AddFxButton({ onAdd }: AddFxButtonProps) {
+export function AddFxButton({ onAdd, availableTypes }: AddFxButtonProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const visibleTypes = availableTypes.length > 0 ? availableTypes : FX_TYPES;
 
   // Close on outside click
   useEffect(() => {
@@ -27,19 +29,24 @@ export function AddFxButton({ onAdd }: AddFxButtonProps) {
   return (
     <div ref={ref} className="relative flex-shrink-0">
       <button
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          if (availableTypes.length > 0) setOpen(!open);
+        }}
+        disabled={availableTypes.length === 0}
         className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-border
-          hover:border-text-dim hover:bg-surface-2/50 transition-colors cursor-pointer"
+          hover:border-text-dim hover:bg-surface-2/50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
         style={{ minWidth: 80, minHeight: 140 }}
         title="Add effect module"
       >
         <span className="text-2xl text-text-dim">+</span>
-        <span className="text-[10px] text-text-dim mt-1">Add FX</span>
+        <span className="text-[10px] text-text-dim mt-1">
+          {availableTypes.length > 0 ? 'Show FX' : 'All Shown'}
+        </span>
       </button>
 
       {open && (
         <div className="absolute bottom-full left-0 mb-2 bg-surface-2 border border-border rounded-lg shadow-xl z-50 py-1 min-w-[140px]">
-          {FX_TYPES.map((type) => {
+          {visibleTypes.map((type) => {
             const meta = FX_CATALOG[type];
             return (
               <button

--- a/ui/src/components/EffectModule.tsx
+++ b/ui/src/components/EffectModule.tsx
@@ -10,6 +10,8 @@ interface EffectModuleProps {
   subtitleOptions?: string[];
   onSubtitleChange?: (val: string) => void;
   icon?: ReactNode;
+  minWidth?: number;
+  controlsClassName?: string;
   children: ReactNode;
 }
 
@@ -23,6 +25,8 @@ export function EffectModule({
   subtitleOptions,
   onSubtitleChange,
   icon,
+  minWidth = 180,
+  controlsClassName = 'flex items-end justify-center gap-4 px-3 py-3',
   children,
 }: EffectModuleProps) {
   return (
@@ -34,7 +38,7 @@ export function EffectModule({
           : '#14142b',
         opacity: enabled ? 1 : 0.5,
         border: `1px solid ${enabled ? color + '40' : '#2a2a4a'}`,
-        minWidth: 180,
+        minWidth,
       }}
     >
       {/* Header */}
@@ -103,7 +107,7 @@ export function EffectModule({
       )}
 
       {/* Controls */}
-      <div className="flex items-end justify-center gap-4 px-3 py-3">
+      <div className={controlsClassName}>
         {children}
       </div>
     </div>

--- a/ui/src/components/InfoBar.tsx
+++ b/ui/src/components/InfoBar.tsx
@@ -75,7 +75,7 @@ export function InfoBar({ selectedBand, eqBands, onShapeChange }: InfoBarProps) 
               disabled={selectedBand === null}
               className={`w-9 h-7 rounded flex items-center justify-center border transition-colors ${
                 isActive
-                  ? 'bg-accent-quantize/20 border-accent-quantize/50 text-accent-quantize'
+                  ? 'bg-accent-retune/20 border-accent-retune/50 text-accent-retune'
                   : 'bg-surface-2 border-border text-text-dim hover:text-text-primary hover:border-text-dim'
               } ${selectedBand === null ? 'opacity-30 cursor-not-allowed' : ''}`}
               title={FILTER_LABELS[shape]}

--- a/ui/src/components/Knob.tsx
+++ b/ui/src/components/Knob.tsx
@@ -132,11 +132,14 @@ export function Knob({
         onPointerUp={onPointerUp}
         onDoubleClick={onDoubleClick}
       />
-      {hovering && displayValue && (
-        <span className="text-[10px] text-text-primary tabular-nums">
-          {displayValue}
+      <div className="h-[14px] flex items-center justify-center">
+        <span
+          className="text-[10px] text-text-primary tabular-nums transition-opacity"
+          style={{ opacity: hovering && displayValue ? 1 : 0 }}
+        >
+          {displayValue ?? '\u00A0'}
         </span>
-      )}
+      </div>
       <span className="text-[10px] text-text-secondary tracking-wider uppercase">
         {label}
       </span>

--- a/ui/src/components/RetuneModule.tsx
+++ b/ui/src/components/RetuneModule.tsx
@@ -1,0 +1,270 @@
+import { EffectModule } from './EffectModule';
+import { Knob } from './Knob';
+import type { EngineParams, RetuneStatus } from '../audio/engine';
+import { NOTE_NAMES, RETUNE_SCALES, buildScaleMask, formatMidiNote } from '../audio/retune';
+
+interface RetuneModuleProps {
+  color: string;
+  params: EngineParams;
+  status: RetuneStatus | null;
+  updateParams: (patch: Partial<EngineParams>) => void;
+  onRemove: () => void;
+}
+
+const SCALE_OPTIONS = Object.keys(RETUNE_SCALES) as Array<keyof typeof RETUNE_SCALES>;
+const OUT_OF_MASK_MODES: EngineParams['retuneOutOfMaskMode'][] = ['nearest', 'preserve', 'mute'];
+
+function formatScaleLabel(scale: string) {
+  return scale.replace('_', ' ');
+}
+
+function formatLatency(ms: number | undefined) {
+  return Number.isFinite(ms) ? `${Math.round(ms ?? 0)} ms` : '—';
+}
+
+export function RetuneModule({
+  color,
+  params,
+  status,
+  updateParams,
+  onRemove,
+}: RetuneModuleProps) {
+  const targetMask = params.retuneTargetMask.length === 12
+    ? params.retuneTargetMask
+    : buildScaleMask(params.retuneKey, params.retuneScale);
+  const sortedNotes = [...(status?.notes ?? [])].sort((a, b) => b.energy - a.energy).slice(0, 6);
+
+  const stateLabel = !params.retuneEnabled
+    ? 'Off'
+    : status?.overloaded
+      ? 'Overloaded'
+      : status?.noteCount
+        ? 'Tracking'
+        : 'Listening';
+
+  const handleKeyChange = (key: number) => {
+    updateParams({
+      retuneKey: key,
+      retuneTargetMask: buildScaleMask(key, params.retuneScale),
+    });
+  };
+
+  const handleScaleChange = (scale: EngineParams['retuneScale']) => {
+    updateParams({
+      retuneScale: scale,
+      retuneTargetMask: buildScaleMask(params.retuneKey, scale),
+    });
+  };
+
+  const handleMaskToggle = (pitchClass: number) => {
+    const nextMask = [...targetMask];
+    const enabledCount = nextMask.filter(Boolean).length;
+    if (nextMask[pitchClass] && enabledCount === 1) {
+      return;
+    }
+    nextMask[pitchClass] = !nextMask[pitchClass];
+    updateParams({ retuneTargetMask: nextMask });
+  };
+
+  return (
+    <EffectModule
+      title="Retune"
+      color={color}
+      enabled={params.retuneEnabled}
+      onToggle={() => updateParams({ retuneEnabled: !params.retuneEnabled })}
+      onRemove={onRemove}
+      subtitle={formatScaleLabel(params.retuneScale)}
+      subtitleOptions={SCALE_OPTIONS}
+      onSubtitleChange={(value) => handleScaleChange(value as EngineParams['retuneScale'])}
+      minWidth={560}
+      controlsClassName="flex flex-col gap-3 px-3 py-3"
+    >
+      <div className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] gap-3">
+        <div className="rounded-lg border border-border bg-surface-2/60 p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Status</div>
+              <div className="mt-1 text-sm font-semibold text-text-primary">{stateLabel}</div>
+            </div>
+            <div className="text-right text-[11px] text-text-secondary">
+              <div>{status?.backendName ?? 'Waiting for engine'}</div>
+              <div>{formatLatency(status?.analysisLatencyMs)}</div>
+            </div>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-text-secondary">
+            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
+              <div className="text-text-dim">Detected</div>
+              <div className="mt-0.5 text-text-primary">{formatMidiNote(status?.notes[0]?.sourceMidi ?? Number.NaN)}</div>
+            </div>
+            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
+              <div className="text-text-dim">Target</div>
+              <div className="mt-0.5 text-text-primary">{formatMidiNote(status?.notes[0]?.targetMidi ?? Number.NaN)}</div>
+            </div>
+            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
+              <div className="text-text-dim">Confidence</div>
+              <div className="mt-0.5 text-text-primary">{status ? `${Math.round(status.confidence * 100)}%` : '—'}</div>
+            </div>
+            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
+              <div className="text-text-dim">Low End</div>
+              <div className="mt-0.5 text-text-primary">
+                {status?.lowEndLocked ? 'Locked' : 'Loose'}
+                {status?.transientBypassActive ? ' · Attack Hold' : ''}
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {sortedNotes.length > 0 ? (
+              sortedNotes.map((note, index) => (
+                <div
+                  key={`${note.sourceMidi}-${note.targetMidi}-${index}`}
+                  className="rounded-md border border-border bg-surface-1/90 px-2 py-1.5 text-[11px] text-text-secondary"
+                >
+                  <div className="flex items-center gap-1.5 text-text-primary">
+                    <span>{formatMidiNote(note.sourceMidi)}</span>
+                    <span className="text-text-dim">→</span>
+                    <span>{formatMidiNote(note.targetMidi)}</span>
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-text-dim">
+                    <span>{note.state}</span>
+                    {note.isLowEnd && <span className="text-[#4ec48a]">Low</span>}
+                    <span>{Math.round(note.confidence * 100)}%</span>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="text-[11px] text-text-dim">No tracked note groups yet.</div>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-surface-2/60 p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Target Mask</div>
+            <button
+              onClick={() => updateParams({ retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale) })}
+              className="rounded border border-border px-2 py-1 text-[10px] uppercase tracking-wide text-text-secondary transition-colors hover:border-text-dim hover:text-text-primary"
+            >
+              Reset
+            </button>
+          </div>
+          <div className="mt-3 grid grid-cols-4 gap-2">
+            {NOTE_NAMES.map((noteName, pitchClass) => {
+              const active = Boolean(targetMask[pitchClass]);
+              const isKeyRoot = pitchClass === params.retuneKey;
+              return (
+                <button
+                  key={noteName}
+                  onClick={() => handleMaskToggle(pitchClass)}
+                  className="rounded-md border px-2 py-2 text-xs font-medium transition-colors"
+                  style={{
+                    background: active ? `${color}22` : '#14142b',
+                    borderColor: active ? `${color}66` : '#3a3a5c',
+                    color: active ? '#e8e8f0' : '#8888a8',
+                    boxShadow: isKeyRoot ? `inset 0 0 0 1px ${color}` : 'none',
+                  }}
+                >
+                  {noteName}
+                </button>
+              );
+            })}
+          </div>
+          <div className="mt-3">
+            <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Out of Mask</div>
+            <div className="mt-2 flex gap-2">
+              {OUT_OF_MASK_MODES.map((mode) => {
+                const active = params.retuneOutOfMaskMode === mode;
+                return (
+                  <button
+                    key={mode}
+                    onClick={() => updateParams({ retuneOutOfMaskMode: mode })}
+                    className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
+                    style={{
+                      background: active ? `${color}22` : '#14142b',
+                      borderColor: active ? `${color}66` : '#3a3a5c',
+                      color: active ? '#e8e8f0' : '#8888a8',
+                    }}
+                  >
+                    {mode}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="mt-3 flex gap-2">
+            <button
+              onClick={() => updateParams({ retunePreserveTransients: !params.retunePreserveTransients })}
+              className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
+              style={{
+                background: params.retunePreserveTransients ? `${color}22` : '#14142b',
+                borderColor: params.retunePreserveTransients ? `${color}66` : '#3a3a5c',
+                color: params.retunePreserveTransients ? '#e8e8f0' : '#8888a8',
+              }}
+            >
+              Preserve Attacks
+            </button>
+            <button
+              onClick={() => updateParams({ retuneCollapseDuplicates: !params.retuneCollapseDuplicates })}
+              className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
+              style={{
+                background: params.retuneCollapseDuplicates ? `${color}22` : '#14142b',
+                borderColor: params.retuneCollapseDuplicates ? `${color}66` : '#3a3a5c',
+                color: params.retuneCollapseDuplicates ? '#e8e8f0' : '#8888a8',
+              }}
+            >
+              Collapse Duplicates
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-end justify-center gap-4">
+        <Knob
+          label="Strength"
+          value={params.retuneStrength}
+          onChange={(value) => updateParams({ retuneStrength: value })}
+          color={color}
+          displayValue={`${Math.round(params.retuneStrength * 100)}%`}
+        />
+        <Knob
+          label="Key"
+          value={params.retuneKey}
+          onChange={(value) => handleKeyChange(Math.round(value))}
+          color={color}
+          min={0}
+          max={11}
+          displayValue={NOTE_NAMES[Math.round(params.retuneKey)]}
+        />
+        <Knob
+          label="Texture"
+          value={params.retuneTextureAmount}
+          onChange={(value) => updateParams({ retuneTextureAmount: value })}
+          color={color}
+          displayValue={`${Math.round(params.retuneTextureAmount * 100)}%`}
+        />
+        <Knob
+          label="Low Blend"
+          value={params.retuneLowEndBlend}
+          onChange={(value) => updateParams({ retuneLowEndBlend: value })}
+          color={color}
+          displayValue={`${Math.round(params.retuneLowEndBlend * 100)}%`}
+        />
+        <Knob
+          label="Sub"
+          value={params.retuneSubReinforcement}
+          onChange={(value) => updateParams({ retuneSubReinforcement: value })}
+          color={color}
+          displayValue={`${Math.round(params.retuneSubReinforcement * 100)}%`}
+        />
+        <Knob
+          label="Air"
+          value={params.retuneAirMix}
+          onChange={(value) => updateParams({ retuneAirMix: value })}
+          color={color}
+          min={0}
+          max={1.5}
+          displayValue={`${Math.round(params.retuneAirMix * 100)}%`}
+        />
+      </div>
+    </EffectModule>
+  );
+}

--- a/ui/src/components/RetuneModule.tsx
+++ b/ui/src/components/RetuneModule.tsx
@@ -297,13 +297,6 @@ export function RetuneModule({
           displayValue={`${Math.round(params.retuneLowEndBlend * 100)}%`}
         />
         <Knob
-          label="Sub"
-          value={params.retuneSubReinforcement}
-          onChange={(value) => updateParams({ retuneSubReinforcement: value })}
-          color={color}
-          displayValue={`${Math.round(params.retuneSubReinforcement * 100)}%`}
-        />
-        <Knob
           label="Air"
           value={params.retuneAirMix}
           onChange={(value) => updateParams({ retuneAirMix: value })}

--- a/ui/src/components/RetuneModule.tsx
+++ b/ui/src/components/RetuneModule.tsx
@@ -1,7 +1,7 @@
 import { EffectModule } from './EffectModule';
 import { Knob } from './Knob';
 import type { EngineParams, RetuneStatus } from '../audio/engine';
-import { NOTE_NAMES, RETUNE_SCALES, buildScaleMask, formatMidiNote } from '../audio/retune';
+import { NOTE_NAMES, RETUNE_SCALES, buildScaleMask } from '../audio/retune';
 
 interface RetuneModuleProps {
   color: string;
@@ -18,10 +18,6 @@ function formatScaleLabel(scale: string) {
   return scale.replace('_', ' ');
 }
 
-function formatLatency(ms: number | undefined) {
-  return Number.isFinite(ms) ? `${Math.round(ms ?? 0)} ms` : '—';
-}
-
 export function RetuneModule({
   color,
   params,
@@ -32,7 +28,6 @@ export function RetuneModule({
   const targetMask = params.retuneTargetMask.length === 12
     ? params.retuneTargetMask
     : buildScaleMask(params.retuneKey, params.retuneScale);
-  const sortedNotes = [...(status?.notes ?? [])].sort((a, b) => b.energy - a.energy).slice(0, 6);
 
   const stateLabel = !params.retuneEnabled
     ? 'Off'
@@ -76,121 +71,84 @@ export function RetuneModule({
       subtitle={formatScaleLabel(params.retuneScale)}
       subtitleOptions={SCALE_OPTIONS}
       onSubtitleChange={(value) => handleScaleChange(value as EngineParams['retuneScale'])}
-      minWidth={560}
+      minWidth={500}
       controlsClassName="flex flex-col gap-3 px-3 py-3"
     >
-      <div className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] gap-3">
-        <div className="rounded-lg border border-border bg-surface-2/60 p-3">
-          <div className="flex items-center justify-between gap-2">
-            <div>
-              <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Status</div>
-              <div className="mt-1 text-sm font-semibold text-text-primary">{stateLabel}</div>
-            </div>
-            <div className="text-right text-[11px] text-text-secondary">
-              <div>{status?.backendName ?? 'Waiting for engine'}</div>
-              <div>{formatLatency(status?.analysisLatencyMs)}</div>
-            </div>
-          </div>
-          <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-text-secondary">
-            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
-              <div className="text-text-dim">Detected</div>
-              <div className="mt-0.5 text-text-primary">{formatMidiNote(status?.notes[0]?.sourceMidi ?? Number.NaN)}</div>
-            </div>
-            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
-              <div className="text-text-dim">Target</div>
-              <div className="mt-0.5 text-text-primary">{formatMidiNote(status?.notes[0]?.targetMidi ?? Number.NaN)}</div>
-            </div>
-            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
-              <div className="text-text-dim">Confidence</div>
-              <div className="mt-0.5 text-text-primary">{status ? `${Math.round(status.confidence * 100)}%` : '—'}</div>
-            </div>
-            <div className="rounded-md bg-surface-1/80 px-2 py-1.5">
-              <div className="text-text-dim">Low End</div>
-              <div className="mt-0.5 text-text-primary">
-                {status?.lowEndLocked ? 'Locked' : 'Loose'}
-                {status?.transientBypassActive ? ' · Attack Hold' : ''}
-              </div>
-            </div>
-          </div>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {sortedNotes.length > 0 ? (
-              sortedNotes.map((note, index) => (
-                <div
-                  key={`${note.sourceMidi}-${note.targetMidi}-${index}`}
-                  className="rounded-md border border-border bg-surface-1/90 px-2 py-1.5 text-[11px] text-text-secondary"
-                >
-                  <div className="flex items-center gap-1.5 text-text-primary">
-                    <span>{formatMidiNote(note.sourceMidi)}</span>
-                    <span className="text-text-dim">→</span>
-                    <span>{formatMidiNote(note.targetMidi)}</span>
-                  </div>
-                  <div className="mt-0.5 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-text-dim">
-                    <span>{note.state}</span>
-                    {note.isLowEnd && <span className="text-[#4ec48a]">Low</span>}
-                    <span>{Math.round(note.confidence * 100)}%</span>
-                  </div>
-                </div>
-              ))
-            ) : (
-              <div className="text-[11px] text-text-dim">No tracked note groups yet.</div>
-            )}
+      <div className="rounded-lg border border-border bg-surface-2/60 px-3 py-2.5">
+        <div className="flex flex-wrap items-center gap-2 text-[11px]">
+          <span className="rounded-full border border-border bg-surface-1/80 px-2.5 py-1 uppercase tracking-[0.24em] text-text-dim">
+            {stateLabel}
+          </span>
+          <span className="text-text-secondary">
+            {status ? `${status.noteCount} groups · ${Math.round(status.confidence * 100)}% conf` : 'Waiting for engine'}
+          </span>
+          {status?.lowEndLocked && (
+            <span className="rounded-full bg-[#4ec48a22] px-2 py-1 text-[#9ce0b8]">
+              Low End Locked
+            </span>
+          )}
+          {status?.transientBypassActive && (
+            <span className="rounded-full bg-surface-1 px-2 py-1 text-text-secondary">
+              Preserve Attacks Active
+            </span>
+          )}
+          <div className="ml-auto text-[11px] text-text-dim">
+            Live note routes are shown in the spectrum.
           </div>
         </div>
+      </div>
 
-        <div className="rounded-lg border border-border bg-surface-2/60 p-3">
-          <div className="flex items-center justify-between gap-2">
-            <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Target Mask</div>
-            <button
-              onClick={() => updateParams({ retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale) })}
-              className="rounded border border-border px-2 py-1 text-[10px] uppercase tracking-wide text-text-secondary transition-colors hover:border-text-dim hover:text-text-primary"
-            >
-              Reset
-            </button>
-          </div>
-          <div className="mt-3 grid grid-cols-4 gap-2">
-            {NOTE_NAMES.map((noteName, pitchClass) => {
-              const active = Boolean(targetMask[pitchClass]);
-              const isKeyRoot = pitchClass === params.retuneKey;
-              return (
-                <button
-                  key={noteName}
-                  onClick={() => handleMaskToggle(pitchClass)}
-                  className="rounded-md border px-2 py-2 text-xs font-medium transition-colors"
-                  style={{
-                    background: active ? `${color}22` : '#14142b',
-                    borderColor: active ? `${color}66` : '#3a3a5c',
-                    color: active ? '#e8e8f0' : '#8888a8',
-                    boxShadow: isKeyRoot ? `inset 0 0 0 1px ${color}` : 'none',
-                  }}
-                >
-                  {noteName}
-                </button>
-              );
-            })}
-          </div>
-          <div className="mt-3">
-            <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Out of Mask</div>
-            <div className="mt-2 flex gap-2">
-              {OUT_OF_MASK_MODES.map((mode) => {
-                const active = params.retuneOutOfMaskMode === mode;
-                return (
-                  <button
-                    key={mode}
-                    onClick={() => updateParams({ retuneOutOfMaskMode: mode })}
-                    className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
-                    style={{
-                      background: active ? `${color}22` : '#14142b',
-                      borderColor: active ? `${color}66` : '#3a3a5c',
-                      color: active ? '#e8e8f0' : '#8888a8',
-                    }}
-                  >
-                    {mode}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-          <div className="mt-3 flex gap-2">
+      <div className="rounded-lg border border-border bg-surface-2/60 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Target Mask</div>
+          <button
+            onClick={() => updateParams({ retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale) })}
+            className="rounded border border-border px-2 py-1 text-[10px] uppercase tracking-wide text-text-secondary transition-colors hover:border-text-dim hover:text-text-primary"
+          >
+            Reset
+          </button>
+        </div>
+        <div className="mt-3 grid grid-cols-6 gap-2">
+          {NOTE_NAMES.map((noteName, pitchClass) => {
+            const active = Boolean(targetMask[pitchClass]);
+            const isKeyRoot = pitchClass === params.retuneKey;
+            return (
+              <button
+                key={noteName}
+                onClick={() => handleMaskToggle(pitchClass)}
+                className="rounded-md border px-2 py-2 text-xs font-medium transition-colors"
+                style={{
+                  background: active ? `${color}22` : '#14142b',
+                  borderColor: active ? `${color}66` : '#3a3a5c',
+                  color: active ? '#e8e8f0' : '#8888a8',
+                  boxShadow: isKeyRoot ? `inset 0 0 0 1px ${color}` : 'none',
+                }}
+              >
+                {noteName}
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Out of Mask</span>
+          {OUT_OF_MASK_MODES.map((mode) => {
+            const active = params.retuneOutOfMaskMode === mode;
+            return (
+              <button
+                key={mode}
+                onClick={() => updateParams({ retuneOutOfMaskMode: mode })}
+                className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
+                style={{
+                  background: active ? `${color}22` : '#14142b',
+                  borderColor: active ? `${color}66` : '#3a3a5c',
+                  color: active ? '#e8e8f0' : '#8888a8',
+                }}
+              >
+                {mode}
+              </button>
+            );
+          })}
+          <div className="ml-auto flex flex-wrap gap-2">
             <button
               onClick={() => updateParams({ retunePreserveTransients: !params.retunePreserveTransients })}
               className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"

--- a/ui/src/components/RetuneModule.tsx
+++ b/ui/src/components/RetuneModule.tsx
@@ -18,6 +18,41 @@ function formatScaleLabel(scale: string) {
   return scale.replace('_', ' ');
 }
 
+function CycleControl({
+  label,
+  value,
+  onPrev,
+  onNext,
+}: {
+  label: string;
+  value: string;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-border bg-surface-1/80 px-2.5 py-2">
+      <span className="text-[10px] uppercase tracking-[0.24em] text-text-dim">{label}</span>
+      <button
+        onClick={onPrev}
+        className="text-text-dim transition-colors hover:text-text-primary"
+        aria-label={`Previous ${label}`}
+      >
+        &#9664;
+      </button>
+      <span className="min-w-[60px] text-center text-xs font-medium capitalize text-text-primary">
+        {value}
+      </span>
+      <button
+        onClick={onNext}
+        className="text-text-dim transition-colors hover:text-text-primary"
+        aria-label={`Next ${label}`}
+      >
+        &#9654;
+      </button>
+    </div>
+  );
+}
+
 export function RetuneModule({
   color,
   params,
@@ -28,6 +63,7 @@ export function RetuneModule({
   const targetMask = params.retuneTargetMask.length === 12
     ? params.retuneTargetMask
     : buildScaleMask(params.retuneKey, params.retuneScale);
+  const scaleIndex = SCALE_OPTIONS.indexOf(params.retuneScale);
 
   const stateLabel = !params.retuneEnabled
     ? 'Off'
@@ -40,14 +76,18 @@ export function RetuneModule({
   const handleKeyChange = (key: number) => {
     updateParams({
       retuneKey: key,
-      retuneTargetMask: buildScaleMask(key, params.retuneScale),
+      ...(params.retuneUseCustomMask
+        ? {}
+        : { retuneTargetMask: buildScaleMask(key, params.retuneScale) }),
     });
   };
 
   const handleScaleChange = (scale: EngineParams['retuneScale']) => {
     updateParams({
       retuneScale: scale,
-      retuneTargetMask: buildScaleMask(params.retuneKey, scale),
+      ...(params.retuneUseCustomMask
+        ? {}
+        : { retuneTargetMask: buildScaleMask(params.retuneKey, scale) }),
     });
   };
 
@@ -61,6 +101,18 @@ export function RetuneModule({
     updateParams({ retuneTargetMask: nextMask });
   };
 
+  const toggleCustomMask = () => {
+    if (params.retuneUseCustomMask) {
+      updateParams({
+        retuneUseCustomMask: false,
+        retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale),
+      });
+      return;
+    }
+
+    updateParams({ retuneUseCustomMask: true });
+  };
+
   return (
     <EffectModule
       title="Retune"
@@ -68,9 +120,6 @@ export function RetuneModule({
       enabled={params.retuneEnabled}
       onToggle={() => updateParams({ retuneEnabled: !params.retuneEnabled })}
       onRemove={onRemove}
-      subtitle={formatScaleLabel(params.retuneScale)}
-      subtitleOptions={SCALE_OPTIONS}
-      onSubtitleChange={(value) => handleScaleChange(value as EngineParams['retuneScale'])}
       minWidth={500}
       controlsClassName="flex flex-col gap-3 px-3 py-3"
     >
@@ -96,83 +145,115 @@ export function RetuneModule({
             Live note routes are shown in the spectrum.
           </div>
         </div>
-      </div>
-
-      <div className="rounded-lg border border-border bg-surface-2/60 p-3">
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Target Mask</div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <CycleControl
+            label="Key"
+            value={NOTE_NAMES[Math.round(params.retuneKey)]}
+            onPrev={() => handleKeyChange((Math.round(params.retuneKey) + 11) % 12)}
+            onNext={() => handleKeyChange((Math.round(params.retuneKey) + 1) % 12)}
+          />
+          <CycleControl
+            label="Scale"
+            value={formatScaleLabel(params.retuneScale)}
+            onPrev={() => handleScaleChange(SCALE_OPTIONS[(scaleIndex - 1 + SCALE_OPTIONS.length) % SCALE_OPTIONS.length])}
+            onNext={() => handleScaleChange(SCALE_OPTIONS[(scaleIndex + 1) % SCALE_OPTIONS.length])}
+          />
           <button
-            onClick={() => updateParams({ retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale) })}
-            className="rounded border border-border px-2 py-1 text-[10px] uppercase tracking-wide text-text-secondary transition-colors hover:border-text-dim hover:text-text-primary"
+            onClick={toggleCustomMask}
+            className="rounded-lg border px-3 py-2 text-[11px] uppercase tracking-[0.2em] transition-colors"
+            style={{
+              background: params.retuneUseCustomMask ? `${color}22` : '#14142b',
+              borderColor: params.retuneUseCustomMask ? `${color}66` : '#3a3a5c',
+              color: params.retuneUseCustomMask ? '#e8e8f0' : '#8888a8',
+            }}
           >
-            Reset
+            Custom
           </button>
         </div>
-        <div className="mt-3 grid grid-cols-6 gap-2">
-          {NOTE_NAMES.map((noteName, pitchClass) => {
-            const active = Boolean(targetMask[pitchClass]);
-            const isKeyRoot = pitchClass === params.retuneKey;
-            return (
-              <button
-                key={noteName}
-                onClick={() => handleMaskToggle(pitchClass)}
-                className="rounded-md border px-2 py-2 text-xs font-medium transition-colors"
-                style={{
-                  background: active ? `${color}22` : '#14142b',
-                  borderColor: active ? `${color}66` : '#3a3a5c',
-                  color: active ? '#e8e8f0' : '#8888a8',
-                  boxShadow: isKeyRoot ? `inset 0 0 0 1px ${color}` : 'none',
-                }}
-              >
-                {noteName}
-              </button>
-            );
-          })}
-        </div>
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <span className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Out of Mask</span>
-          {OUT_OF_MASK_MODES.map((mode) => {
-            const active = params.retuneOutOfMaskMode === mode;
-            return (
-              <button
-                key={mode}
-                onClick={() => updateParams({ retuneOutOfMaskMode: mode })}
-                className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
-                style={{
-                  background: active ? `${color}22` : '#14142b',
-                  borderColor: active ? `${color}66` : '#3a3a5c',
-                  color: active ? '#e8e8f0' : '#8888a8',
-                }}
-              >
-                {mode}
-              </button>
-            );
-          })}
-          <div className="ml-auto flex flex-wrap gap-2">
+      </div>
+
+      {params.retuneUseCustomMask ? (
+        <div className="rounded-lg border border-border bg-surface-2/60 p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Target Mask</div>
             <button
-              onClick={() => updateParams({ retunePreserveTransients: !params.retunePreserveTransients })}
-              className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
-              style={{
-                background: params.retunePreserveTransients ? `${color}22` : '#14142b',
-                borderColor: params.retunePreserveTransients ? `${color}66` : '#3a3a5c',
-                color: params.retunePreserveTransients ? '#e8e8f0' : '#8888a8',
-              }}
+              onClick={() => updateParams({ retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale) })}
+              className="rounded border border-border px-2 py-1 text-[10px] uppercase tracking-wide text-text-secondary transition-colors hover:border-text-dim hover:text-text-primary"
             >
-              Preserve Attacks
-            </button>
-            <button
-              onClick={() => updateParams({ retuneCollapseDuplicates: !params.retuneCollapseDuplicates })}
-              className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
-              style={{
-                background: params.retuneCollapseDuplicates ? `${color}22` : '#14142b',
-                borderColor: params.retuneCollapseDuplicates ? `${color}66` : '#3a3a5c',
-                color: params.retuneCollapseDuplicates ? '#e8e8f0' : '#8888a8',
-              }}
-            >
-              Collapse Duplicates
+              Reset To Scale
             </button>
           </div>
+          <div className="mt-3 grid grid-cols-6 gap-2">
+            {NOTE_NAMES.map((noteName, pitchClass) => {
+              const active = Boolean(targetMask[pitchClass]);
+              const isKeyRoot = pitchClass === params.retuneKey;
+              return (
+                <button
+                  key={noteName}
+                  onClick={() => handleMaskToggle(pitchClass)}
+                  className="rounded-md border px-2 py-2 text-xs font-medium transition-colors"
+                  style={{
+                    background: active ? `${color}22` : '#14142b',
+                    borderColor: active ? `${color}66` : '#3a3a5c',
+                    color: active ? '#e8e8f0' : '#8888a8',
+                    boxShadow: isKeyRoot ? `inset 0 0 0 1px ${color}` : 'none',
+                  }}
+                >
+                  {noteName}
+                </button>
+              );
+            })}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Out of Mask</span>
+            {OUT_OF_MASK_MODES.map((mode) => {
+              const active = params.retuneOutOfMaskMode === mode;
+              return (
+                <button
+                  key={mode}
+                  onClick={() => updateParams({ retuneOutOfMaskMode: mode })}
+                  className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
+                  style={{
+                    background: active ? `${color}22` : '#14142b',
+                    borderColor: active ? `${color}66` : '#3a3a5c',
+                    color: active ? '#e8e8f0' : '#8888a8',
+                  }}
+                >
+                  {mode}
+                </button>
+              );
+            })}
+          </div>
         </div>
+      ) : (
+        <div className="rounded-lg border border-border bg-surface-2/60 px-3 py-2.5 text-[11px] text-text-secondary">
+          Targets follow <span className="text-text-primary">{NOTE_NAMES[Math.round(params.retuneKey)]} {formatScaleLabel(params.retuneScale)}</span> automatically.
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={() => updateParams({ retunePreserveTransients: !params.retunePreserveTransients })}
+          className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
+          style={{
+            background: params.retunePreserveTransients ? `${color}22` : '#14142b',
+            borderColor: params.retunePreserveTransients ? `${color}66` : '#3a3a5c',
+            color: params.retunePreserveTransients ? '#e8e8f0' : '#8888a8',
+          }}
+        >
+          Preserve Attacks
+        </button>
+        <button
+          onClick={() => updateParams({ retuneCollapseDuplicates: !params.retuneCollapseDuplicates })}
+          className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
+          style={{
+            background: params.retuneCollapseDuplicates ? `${color}22` : '#14142b',
+            borderColor: params.retuneCollapseDuplicates ? `${color}66` : '#3a3a5c',
+            color: params.retuneCollapseDuplicates ? '#e8e8f0' : '#8888a8',
+          }}
+        >
+          Collapse Duplicates
+        </button>
       </div>
 
       <div className="flex flex-wrap items-end justify-center gap-4">
@@ -184,13 +265,22 @@ export function RetuneModule({
           displayValue={`${Math.round(params.retuneStrength * 100)}%`}
         />
         <Knob
-          label="Key"
-          value={params.retuneKey}
-          onChange={(value) => handleKeyChange(Math.round(value))}
+          label="Deadband"
+          value={params.retuneDeadbandCents}
+          onChange={(value) => updateParams({ retuneDeadbandCents: value })}
           color={color}
           min={0}
-          max={11}
-          displayValue={NOTE_NAMES[Math.round(params.retuneKey)]}
+          max={40}
+          displayValue={`${Math.round(params.retuneDeadbandCents)} cents`}
+        />
+        <Knob
+          label="Gate"
+          value={params.retuneConfidenceGate}
+          onChange={(value) => updateParams({ retuneConfidenceGate: value })}
+          color={color}
+          min={0}
+          max={0.6}
+          displayValue={`${Math.round(params.retuneConfidenceGate * 100)}%`}
         />
         <Knob
           label="Texture"

--- a/ui/src/components/SpectrumAnalyzer.tsx
+++ b/ui/src/components/SpectrumAnalyzer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback, useState } from 'react';
 import type { EQBand } from '../audio/engine';
 
 interface SpectrumAnalyzerProps {
@@ -80,8 +80,9 @@ export function SpectrumAnalyzer({ analyser, eqBands, onBandChange, width, heigh
   const animRef = useRef<number>(0);
   const draggingBand = useRef<number | null>(null);
   const hoverBand = useRef<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
 
-  const draw = useCallback(() => {
+  const drawFrame = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d')!;
@@ -243,14 +244,17 @@ export function SpectrumAnalyzer({ analyser, eqBands, onBandChange, width, heigh
       const x = freqToX(FREQ_VALUES[i], width);
       ctx.fillText(String(FREQ_LABELS[i]), x, height - 4);
     }
-
-    animRef.current = requestAnimationFrame(draw);
   }, [analyser, eqBands, width, height]);
 
   useEffect(() => {
-    animRef.current = requestAnimationFrame(draw);
+    const render = () => {
+      drawFrame();
+      animRef.current = requestAnimationFrame(render);
+    };
+
+    animRef.current = requestAnimationFrame(render);
     return () => cancelAnimationFrame(animRef.current);
-  }, [draw]);
+  }, [drawFrame]);
 
   // Hit testing for band nodes
   const findBandAt = useCallback((clientX: number, clientY: number): number | null => {
@@ -273,6 +277,7 @@ export function SpectrumAnalyzer({ analyser, eqBands, onBandChange, width, heigh
     const idx = findBandAt(e.clientX, e.clientY);
     if (idx !== null) {
       draggingBand.current = idx;
+      setIsDragging(true);
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     }
   }, [findBandAt]);
@@ -294,17 +299,22 @@ export function SpectrumAnalyzer({ analyser, eqBands, onBandChange, width, heigh
 
   const onPointerUp = useCallback(() => {
     draggingBand.current = null;
+    setIsDragging(false);
   }, []);
 
   return (
     <canvas
       ref={canvasRef}
-      style={{ width, height, cursor: draggingBand.current !== null ? 'grabbing' : 'crosshair' }}
+      style={{ width, height, cursor: isDragging ? 'grabbing' : 'crosshair' }}
       className="block rounded-lg"
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
-      onPointerLeave={() => { hoverBand.current = null; }}
+      onPointerLeave={() => {
+        hoverBand.current = null;
+        draggingBand.current = null;
+        setIsDragging(false);
+      }}
     />
   );
 }

--- a/ui/src/components/SpectrumAnalyzer.tsx
+++ b/ui/src/components/SpectrumAnalyzer.tsx
@@ -1,9 +1,14 @@
 import { useRef, useEffect, useCallback, useState } from 'react';
-import type { EQBand } from '../audio/engine';
+import type { EQBand, RetuneStatus } from '../audio/engine';
+import { formatMidiNote, midiToFreq, NOTE_NAMES } from '../audio/retune';
 
 interface SpectrumAnalyzerProps {
   analyser: AnalyserNode | null;
   eqBands: EQBand[];
+  retuneStatus: RetuneStatus | null;
+  retuneEnabled: boolean;
+  retuneKey: number;
+  retuneScale: string;
   onBandChange: (index: number, band: Partial<EQBand>) => void;
   width: number;
   height: number;
@@ -15,6 +20,11 @@ const FREQ_VALUES = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000];
 
 // Band colors matching the effect module accents
 const BAND_COLORS = ['#c45e3e', '#4a6fa5', '#4ec48a', '#8a5ec4', '#3eafc4'];
+const RETUNE_STATE_COLORS = {
+  mapped: '#4ec48a',
+  preserved: '#8b90ad',
+  muted: '#d96b6b',
+} as const;
 
 function freqToX(freq: number, width: number): number {
   const minLog = Math.log10(20);
@@ -36,6 +46,35 @@ function gainToY(gain: number, height: number): number {
 
 function yToGain(y: number, height: number): number {
   return -((y - height / 2) / (height / 2)) * 24;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + width - radius, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+  ctx.lineTo(x + width, y + height - radius);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  ctx.lineTo(x + radius, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+}
+
+function formatKeyLabel(key: number): string {
+  return NOTE_NAMES[((Math.round(key) % 12) + 12) % 12];
 }
 
 /** Compute approximate EQ response contribution for a single band at a given frequency */
@@ -75,7 +114,17 @@ function bandResponse(band: EQBand, freq: number): number {
   }
 }
 
-export function SpectrumAnalyzer({ analyser, eqBands, onBandChange, width, height }: SpectrumAnalyzerProps) {
+export function SpectrumAnalyzer({
+  analyser,
+  eqBands,
+  retuneStatus,
+  retuneEnabled,
+  retuneKey,
+  retuneScale,
+  onBandChange,
+  width,
+  height,
+}: SpectrumAnalyzerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animRef = useRef<number>(0);
   const draggingBand = useRef<number | null>(null);
@@ -244,7 +293,92 @@ export function SpectrumAnalyzer({ analyser, eqBands, onBandChange, width, heigh
       const x = freqToX(FREQ_VALUES[i], width);
       ctx.fillText(String(FREQ_LABELS[i]), x, height - 4);
     }
-  }, [analyser, eqBands, width, height]);
+
+    if (retuneEnabled) {
+      const overlayNotes = [...(retuneStatus?.notes ?? [])]
+        .sort((a, b) => b.energy - a.energy)
+        .slice(0, 4);
+      const overlayHeight = 42 + overlayNotes.length * 18;
+      const overlayWidth = width - 24;
+
+      ctx.save();
+      drawRoundedRect(ctx, 12, 12, overlayWidth, overlayHeight, 12);
+      const overlayGradient = ctx.createLinearGradient(12, 12, 12, 12 + overlayHeight);
+      overlayGradient.addColorStop(0, 'rgba(13, 13, 26, 0.9)');
+      overlayGradient.addColorStop(1, 'rgba(20, 20, 43, 0.76)');
+      ctx.fillStyle = overlayGradient;
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(78, 196, 138, 0.22)';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+
+      ctx.textAlign = 'left';
+      ctx.font = '11px Inter, sans-serif';
+      ctx.fillStyle = '#e8e8f0';
+      const stateLabel = !retuneStatus
+        ? 'Waiting'
+        : retuneStatus.overloaded
+          ? 'Overloaded'
+          : retuneStatus.noteCount > 0
+            ? 'Tracking'
+            : 'Listening';
+      ctx.fillText(`RETUNE ${formatKeyLabel(retuneKey)} ${retuneScale.replace('_', ' ')} · ${stateLabel}`, 24, 31);
+
+      ctx.font = '10px Inter, sans-serif';
+      ctx.fillStyle = '#8888a8';
+      const meta = [
+        `${retuneStatus?.noteCount ?? 0} groups`,
+        retuneStatus ? `${Math.round(retuneStatus.confidence * 100)}% conf` : 'no lock',
+        retuneStatus?.lowEndLocked ? 'low locked' : 'low floating',
+      ];
+      if (retuneStatus?.transientBypassActive) {
+        meta.push('attack hold');
+      }
+      ctx.fillText(meta.join(' · '), 24, 47);
+
+      overlayNotes.forEach((note, index) => {
+        const sourceX = clamp(freqToX(midiToFreq(note.sourceMidi), width), 90, width - 24);
+        const targetX = clamp(freqToX(midiToFreq(note.targetMidi), width), 90, width - 24);
+        const y = 67 + index * 18;
+        const color = RETUNE_STATE_COLORS[note.state];
+        const label = note.state === 'mapped'
+          ? `${formatMidiNote(note.sourceMidi)} → ${formatMidiNote(note.targetMidi)}`
+          : `${formatMidiNote(note.sourceMidi)} ${note.state}`;
+
+        ctx.strokeStyle = `${color}cc`;
+        ctx.lineWidth = note.isLowEnd ? 2.2 : 1.4;
+        ctx.beginPath();
+        ctx.moveTo(sourceX, y);
+        ctx.lineTo(targetX, y);
+        ctx.stroke();
+
+        ctx.fillStyle = '#0d0d1a';
+        ctx.beginPath();
+        ctx.arc(sourceX, y, 3.5, 0, 2 * Math.PI);
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.beginPath();
+        ctx.arc(targetX, y, 4.5, 0, 2 * Math.PI);
+        ctx.fill();
+        ctx.stroke();
+
+        const chipText = note.isLowEnd ? `${label} · LOW` : label;
+        ctx.font = '10px Inter, sans-serif';
+        const chipWidth = ctx.measureText(chipText).width + 14;
+        const chipX = clamp((sourceX + targetX) / 2 - chipWidth / 2, 96, width - chipWidth - 18);
+        drawRoundedRect(ctx, chipX, y - 10, chipWidth, 16, 8);
+        ctx.fillStyle = 'rgba(20, 20, 43, 0.94)';
+        ctx.fill();
+        ctx.strokeStyle = `${color}55`;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.fillStyle = note.state === 'muted' ? '#f3b2b2' : '#d7d9e5';
+        ctx.fillText(chipText, chipX + 7, y + 4);
+      });
+      ctx.restore();
+    }
+  }, [analyser, eqBands, retuneEnabled, retuneKey, retuneScale, retuneStatus, width, height]);
 
   useEffect(() => {
     const render = () => {

--- a/ui/src/components/Toolbar.tsx
+++ b/ui/src/components/Toolbar.tsx
@@ -33,8 +33,8 @@ export function Toolbar({
     <div className="flex items-center gap-3 px-4 py-2 bg-surface-1 border-b border-border">
       {/* Logo */}
       <div className="flex items-center gap-2 mr-2">
-        <div className="w-6 h-6 rounded bg-accent-quantize/20 flex items-center justify-center">
-          <span className="text-accent-quantize text-xs font-bold">Q</span>
+        <div className="w-6 h-6 rounded bg-accent-retune/20 flex items-center justify-center">
+          <span className="text-accent-retune text-xs font-bold">Q</span>
         </div>
         <span className="text-sm font-semibold tracking-wide text-text-primary">
           QUANTUM DISTORTION

--- a/ui/src/hooks/useAudioEngine.ts
+++ b/ui/src/hooks/useAudioEngine.ts
@@ -1,22 +1,26 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
 import { AudioEngine, DEFAULT_PARAMS } from '../audio/engine';
-import type { EngineParams } from '../audio/engine';
+import type { EngineParams, RetuneStatus } from '../audio/engine';
 
 export function useAudioEngine() {
   const engineRef = useRef<AudioEngine | null>(null);
+  const [engine, setEngine] = useState<AudioEngine | null>(null);
   const [isReady, setIsReady] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
   const [fileName, setFileName] = useState<string | null>(null);
   const [duration, setDuration] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
   const [params, setParams] = useState<EngineParams>(DEFAULT_PARAMS);
+  const [retuneStatus, setRetuneStatus] = useState<RetuneStatus | null>(null);
   const animRef = useRef<number>(0);
 
   const init = useCallback(async () => {
     if (engineRef.current) return;
     const engine = new AudioEngine();
     await engine.init();
+    engine.setRetuneStatusCallback(setRetuneStatus);
     engineRef.current = engine;
+    setEngine(engine);
     setIsReady(true);
   }, []);
 
@@ -83,13 +87,14 @@ export function useAudioEngine() {
   }, [isPlaying]);
 
   return {
-    engine: engineRef.current,
+    engine,
     isReady,
     isPlaying,
     fileName,
     duration,
     currentTime,
     params,
+    retuneStatus,
     init,
     loadFile,
     play,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -11,6 +11,7 @@
   --color-accent-delay: #3eafc4;
   --color-accent-modulate: #8a5ec4;
   --color-accent-lofi: #8a7e5e;
+  --color-accent-retune: #4ec48a;
   --color-accent-quantize: #4ec48a;
   --color-text-primary: #e8e8f0;
   --color-text-secondary: #8888a8;

--- a/ui/tests/retune-core.test.mjs
+++ b/ui/tests/retune-core.test.mjs
@@ -1,0 +1,196 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildScaleMask,
+  normalizeRetuneParamPatch,
+  PolyphonicRetuneCore,
+} from '../public/worklets/retune-core.js';
+
+const SAMPLE_RATE = 48_000;
+const BLOCK_SIZE = 128;
+
+function createCore(params = {}) {
+  const core = new PolyphonicRetuneCore({ sampleRate: SAMPLE_RATE, maxChannels: 2 });
+  core.setParams({ retuneEnabled: true, ...params });
+  return core;
+}
+
+function renderSignal({ seconds = 1.4, params = {}, sampleAt }) {
+  const core = createCore(params);
+  const totalSamples = Math.ceil(seconds * SAMPLE_RATE);
+  const totalBlocks = Math.ceil(totalSamples / BLOCK_SIZE);
+  const output = [];
+  const statuses = [];
+  let inputEnergy = 0;
+
+  for (let blockIndex = 0; blockIndex < totalBlocks; blockIndex++) {
+    const left = new Float32Array(BLOCK_SIZE);
+    const right = new Float32Array(BLOCK_SIZE);
+
+    for (let i = 0; i < BLOCK_SIZE; i++) {
+      const sampleIndex = blockIndex * BLOCK_SIZE + i;
+      const time = sampleIndex / SAMPLE_RATE;
+      const sample = sampleIndex < totalSamples ? sampleAt(sampleIndex, time) : 0;
+      left[i] = sample;
+      right[i] = sample;
+      inputEnergy += sample * sample;
+    }
+
+    const processed = core.processBlock([left, right], 2, BLOCK_SIZE, { lowGain: 1, highGain: 1 });
+    for (let i = 0; i < BLOCK_SIZE; i++) {
+      output.push(processed[0][i]);
+    }
+    statuses.push(core.getStatus());
+  }
+
+  const outputEnergy = output.reduce((sum, sample) => sum + sample * sample, 0);
+  return {
+    core,
+    status: core.getStatus(),
+    statuses,
+    inputRms: Math.sqrt(inputEnergy / (totalBlocks * BLOCK_SIZE)),
+    outputRms: Math.sqrt(outputEnergy / output.length),
+  };
+}
+
+function findNote(notes, predicate) {
+  return notes.find(predicate);
+}
+
+test('normalizes legacy quantize params into retune params', () => {
+  const normalized = normalizeRetuneParamPatch({
+    quantizeEnabled: true,
+    quantizeKey: 2,
+    quantizeScale: 'minor',
+    quantizeStrength: 0.82,
+    quantizeSubLevel: 0.41,
+  });
+
+  assert.equal(normalized.retuneEnabled, true);
+  assert.equal(normalized.retuneKey, 2);
+  assert.equal(normalized.retuneScale, 'minor');
+  assert.equal(normalized.retuneStrength, 0.82);
+  assert.equal(normalized.retuneSubReinforcement, 0.41);
+  assert.deepEqual(normalized.retuneTargetMask, buildScaleMask(2, 'minor'));
+});
+
+test('tracks low-end notes and remaps them to the nearest allowed pitch class', () => {
+  const result = renderSignal({
+    params: {
+      retuneKey: 0,
+      retuneScale: 'major',
+      retuneLowEndBlend: 0.75,
+      retuneSubReinforcement: 0,
+    },
+    sampleAt(sampleIndex) {
+      return (
+        Math.sin((2 * Math.PI * 46.2493028389543 * sampleIndex) / SAMPLE_RATE) * 0.7
+        + Math.sin((2 * Math.PI * 92.4986056779086 * sampleIndex) / SAMPLE_RATE) * 0.2
+      );
+    },
+  });
+
+  const trackedLow = findNote(
+    result.status.notes,
+    (note) => note.isLowEnd && Math.abs(note.sourceMidi - 30) < 0.75,
+  );
+
+  assert.ok(trackedLow, 'expected a tracked low-end note near F#1');
+  assert.equal(trackedLow.state, 'mapped');
+  assert.ok(Math.abs(trackedLow.targetMidi - 31) < 0.75, `expected low-end target near G1, got ${trackedLow.targetMidi}`);
+  assert.equal(result.status.lowEndLocked, true);
+  assert.equal(result.status.analysisLatencyMs, 64);
+});
+
+test('keeps multiple tracked note objects for dyads', () => {
+  const result = renderSignal({
+    params: { retuneKey: 0, retuneScale: 'major' },
+    sampleAt(sampleIndex) {
+      return (
+        Math.sin((2 * Math.PI * 440 * sampleIndex) / SAMPLE_RATE) * 0.35
+        + Math.sin((2 * Math.PI * 523.2511306011972 * sampleIndex) / SAMPLE_RATE) * 0.35
+      );
+    },
+  });
+
+  const a4 = findNote(result.status.notes, (note) => !note.isLowEnd && Math.abs(note.sourceMidi - 69) < 1);
+  const c5 = findNote(result.status.notes, (note) => !note.isLowEnd && Math.abs(note.sourceMidi - 72) < 1);
+
+  assert.ok(a4, 'expected a tracked A4 note object');
+  assert.ok(c5, 'expected a tracked C5 note object');
+  assert.ok(result.status.noteCount >= 2, `expected multiple note groups, got ${result.status.noteCount}`);
+});
+
+test('preserve mode leaves out-of-mask notes alone while mute mode suppresses them', () => {
+  const cOnlyMask = new Array(12).fill(false);
+  cOnlyMask[0] = true;
+
+  const preserveResult = renderSignal({
+    params: {
+      retuneTargetMask: cOnlyMask,
+      retuneOutOfMaskMode: 'preserve',
+    },
+    sampleAt(sampleIndex) {
+      return Math.sin((2 * Math.PI * 369.9944227116344 * sampleIndex) / SAMPLE_RATE) * 0.8;
+    },
+  });
+
+  const preserved = findNote(
+    preserveResult.status.notes,
+    (note) => !note.isLowEnd && Math.abs(note.sourceMidi - 66) < 1,
+  );
+  assert.ok(preserved, 'expected a tracked F#4 note');
+  assert.equal(preserved.state, 'preserved');
+  assert.ok(Math.abs(preserved.targetMidi - preserved.sourceMidi) < 0.75);
+
+  const muteResult = renderSignal({
+    params: {
+      retuneTargetMask: cOnlyMask,
+      retuneOutOfMaskMode: 'mute',
+    },
+    sampleAt(sampleIndex) {
+      return Math.sin((2 * Math.PI * 369.9944227116344 * sampleIndex) / SAMPLE_RATE) * 0.8;
+    },
+  });
+
+  const muted = findNote(
+    muteResult.status.notes,
+    (note) => !note.isLowEnd && Math.abs(note.sourceMidi - 66) < 1,
+  );
+  assert.ok(muted, 'expected a muted F#4 note object');
+  assert.equal(muted.state, 'muted');
+  assert.ok(muteResult.outputRms < muteResult.inputRms * 0.2, `expected muted output to drop strongly, got ${muteResult.outputRms}`);
+});
+
+test('transient preservation reports attack bypass on note onsets', () => {
+  const result = renderSignal({
+    params: { retunePreserveTransients: true },
+    sampleAt(sampleIndex, time) {
+      const env = time < 0.2 ? 0 : time < 0.22 ? (time - 0.2) / 0.02 : 1;
+      return env * (
+        Math.sin((2 * Math.PI * 440 * sampleIndex) / SAMPLE_RATE) * 0.45
+        + Math.sin((2 * Math.PI * 554.3652619537442 * sampleIndex) / SAMPLE_RATE) * 0.3
+      );
+    },
+  });
+
+  assert.ok(
+    result.statuses.some((status) => status.transientBypassActive),
+    'expected transient bypass to activate during the attack window',
+  );
+});
+
+test('noise stays low-confidence and near-unity ratio', () => {
+  let seed = 1;
+  const result = renderSignal({
+    params: { retuneKey: 0, retuneScale: 'major' },
+    sampleAt() {
+      seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+      return ((seed / 4_294_967_295) * 2 - 1) * 0.35;
+    },
+  });
+
+  assert.ok(result.status.confidence < 0.2, `expected low confidence on noise, got ${result.status.confidence}`);
+  assert.ok(Math.abs(result.status.smoothedRatio - 1) < 0.05, `expected near-unity ratio on noise, got ${result.status.smoothedRatio}`);
+});

--- a/ui/tests/retune-core.test.mjs
+++ b/ui/tests/retune-core.test.mjs
@@ -47,6 +47,7 @@ function renderSignal({ seconds = 1.4, params = {}, sampleAt }) {
   const outputEnergy = output.reduce((sum, sample) => sum + sample * sample, 0);
   return {
     core,
+    output,
     status: core.getStatus(),
     statuses,
     inputRms: Math.sqrt(inputEnergy / (totalBlocks * BLOCK_SIZE)),
@@ -56,6 +57,17 @@ function renderSignal({ seconds = 1.4, params = {}, sampleAt }) {
 
 function findNote(notes, predicate) {
   return notes.find(predicate);
+}
+
+function measureFrequencyAmplitude(samples, frequency) {
+  let real = 0;
+  let imag = 0;
+  for (let i = 0; i < samples.length; i++) {
+    const phase = (2 * Math.PI * frequency * i) / SAMPLE_RATE;
+    real += samples[i] * Math.cos(phase);
+    imag -= samples[i] * Math.sin(phase);
+  }
+  return Math.hypot(real, imag) / samples.length;
 }
 
 test('normalizes legacy quantize params into retune params', () => {
@@ -193,4 +205,29 @@ test('noise stays low-confidence and near-unity ratio', () => {
 
   assert.ok(result.status.confidence < 0.2, `expected low confidence on noise, got ${result.status.confidence}`);
   assert.ok(Math.abs(result.status.smoothedRatio - 1) < 0.05, `expected near-unity ratio on noise, got ${result.status.smoothedRatio}`);
+});
+
+test('in-scale notes inside the correction window are not pulled hard to equal temperament', () => {
+  const targetFreq = 293.6647679174076; // D4
+  const sourceFreq = targetFreq * Math.pow(2, 14 / 1200);
+  const result = renderSignal({
+    params: {
+      retuneKey: 2,
+      retuneScale: 'minor',
+      retuneStrength: 1,
+      retuneTextureAmount: 0,
+      retuneSubReinforcement: 0,
+    },
+    sampleAt(sampleIndex) {
+      return Math.sin((2 * Math.PI * sourceFreq * sampleIndex) / SAMPLE_RATE) * 0.7;
+    },
+  });
+
+  const sourceAmplitude = measureFrequencyAmplitude(result.output.slice(Math.floor(result.output.length * 0.4)), sourceFreq);
+  const targetAmplitude = measureFrequencyAmplitude(result.output.slice(Math.floor(result.output.length * 0.4)), targetFreq);
+
+  assert.ok(
+    sourceAmplitude >= targetAmplitude * 0.9,
+    `expected in-scale note to stay near its original pitch window, got source=${sourceAmplitude} target=${targetAmplitude}`,
+  );
 });

--- a/ui/tests/retune-core.test.mjs
+++ b/ui/tests/retune-core.test.mjs
@@ -76,14 +76,12 @@ test('normalizes legacy quantize params into retune params', () => {
     quantizeKey: 2,
     quantizeScale: 'minor',
     quantizeStrength: 0.82,
-    quantizeSubLevel: 0.41,
   });
 
   assert.equal(normalized.retuneEnabled, true);
   assert.equal(normalized.retuneKey, 2);
   assert.equal(normalized.retuneScale, 'minor');
   assert.equal(normalized.retuneStrength, 0.82);
-  assert.equal(normalized.retuneSubReinforcement, 0.41);
   assert.deepEqual(normalized.retuneTargetMask, buildScaleMask(2, 'minor'));
 });
 
@@ -93,7 +91,6 @@ test('tracks low-end notes and remaps them to the nearest allowed pitch class', 
       retuneKey: 0,
       retuneScale: 'major',
       retuneLowEndBlend: 0.75,
-      retuneSubReinforcement: 0,
     },
     sampleAt(sampleIndex) {
       return (
@@ -216,7 +213,6 @@ test('in-scale notes inside the correction window are not pulled hard to equal t
       retuneScale: 'minor',
       retuneStrength: 1,
       retuneTextureAmount: 0,
-      retuneSubReinforcement: 0,
     },
     sampleAt(sampleIndex) {
       return Math.sin((2 * Math.PI * sourceFreq * sampleIndex) / SAMPLE_RATE) * 0.7;


### PR DESCRIPTION
## Summary
- rebuild the Electron app around an extracted polyphonic retune core running inside the AudioWorklet
- replace the previous monolithic/mono-flavored retune path with persistent tracked note objects, spectral note-group remapping, and a hybrid low-end lane
- simplify the Electron retune surface, move live note-route feedback into the spectrum, expose user-facing tolerance controls, and split sub follow into its own downstream module

## What Changed
### Retune architecture
- added a dedicated retune engine in `ui/public/worklets/retune-core.js`
- reduced `ui/public/worklets/quantum-processor.js` to transport/effect hosting around that core
- unified the Electron-facing contract around `retune*` parameters in `ui/src/audio/engine.ts`
- documented the redesign direction in `docs/polyphonic-retune-redesign.md`

### DSP behavior
- introduced persistent note tracking with hysteresis and confidence-aware target locking
- added low-end analysis/resynthesis and live low-note guidance for downstream sub follow
- reduced in-scale overcorrection by adding a correction deadband / soft ramp instead of always snapping valid notes toward equal temperament
- added confidence gating so ambiguous material is preserved instead of being aggressively remapped
- moved synthetic sub reinforcement out of the retune core and into its own post-`Saturate 2` module

### UI / UX
- replaced the old retune panel with a more compact control surface
- key and scale now live at the top of the retune module
- added a `Custom` mode that reveals the target mask only when needed
- moved live note-routing feedback into the spectrum overlay
- exposed user-facing retune tolerance controls (`Deadband`, `Gate`)
- fixed knob hover layout jitter so FX modules no longer jump on hover
- kept singleton FX behavior honest and added a standalone `Sub` module

### Tests
- added deterministic regression coverage in `ui/tests/retune-core.test.mjs`
- covered low-end remap, dyad tracking, preserve/mute behavior, transient bypass, noise rejection, and in-scale deadband behavior

## Validation
- `npm run test:retune-core`
- `npm run lint`
- `npm run build`
- `node --check ui/public/worklets/quantum-processor.js`
- `node --check ui/public/worklets/retune-core.js`

## Commit History
- `c407066` refactor: unify electron retune contract
- `37edbc3` test: harden retune core regression coverage
- `721a16d` feat: stabilize retune locking and simplify feedback
- `07ac20a` fix: reduce in-scale overcorrection
- `1c05af2` fix: stop knob hover layout jitter
- `16755ee` feat: streamline retune controls and expose tolerance
- `1760b0c` feat: split sub follow from retune core
