### PR TITLE
UI refactor: modular module shell, retune/spectrum redesign, and engine param additions

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,83 +1,60 @@
-import { useCallback, useRef, useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Toolbar } from './components/Toolbar';
-import { InfoBar } from './components/InfoBar';
 import { SpectrumAnalyzer } from './components/SpectrumAnalyzer';
-import { EffectModule } from './components/EffectModule';
-import { Knob } from './components/Knob';
-import { AddFxButton } from './components/AddFxButton';
 import { RetuneModule } from './components/RetuneModule';
+import { Knob } from './components/Knob';
 import { useAudioEngine } from './hooks/useAudioEngine';
-import { FX_CATALOG } from './audio/engine';
-import type { EQBand, FilterType, FxSlot, FxType, EngineParams, PeqInstance } from './audio/engine';
 
-const FX_ORDER: FxType[] = ['peq', 'saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2', 'sub'];
-const SINGLETON_FX: FxType[] = ['saturate', 'retune', 'delay', 'modulate', 'lofi', 'saturate2', 'sub'];
-
-// Electron API type
 declare global {
   interface Window {
     electronAPI?: {
       openAudioFile: () => Promise<{ name: string; buffer: ArrayBuffer } | null>;
-      saveAudioFile: (buffer: ArrayBuffer, name: string) => Promise<boolean>;
     };
   }
 }
 
-// --- Output Module (always last, not removable) ---
-function OutputModule({ params, updateParams }: {
-  params: EngineParams;
-  updateParams: (p: Partial<EngineParams>) => void;
+const SAT_TYPES = ['Analog Tape', 'Tube', 'Diode Clip', 'Foldback', 'Soft Clip'];
+const SOFTNESS = ['Soft', 'Medium', 'Hard'];
+const NOTE_OPTIONS = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+function ModuleShell({
+  number,
+  title,
+  color,
+  enabled,
+  onToggle,
+  minWidth,
+  children,
+}: {
+  number?: string;
+  title: string;
+  color: string;
+  enabled: boolean;
+  onToggle: () => void;
+  minWidth: number;
+  children: ReactNode;
 }) {
   return (
     <div
       className="flex flex-col rounded-xl overflow-hidden flex-shrink-0"
       style={{
-        background: 'linear-gradient(180deg, #3eafc418 0%, #14142b 100%)',
-        border: '1px solid #3eafc440',
-        minWidth: 180,
+        background: `linear-gradient(180deg, ${color}16 0%, #14142b 100%)`,
+        border: `1px solid ${color}4a`,
+        minWidth,
+        opacity: enabled ? 1 : 0.6,
       }}
     >
-      <div className="flex items-center gap-2 px-3 py-2">
-        <span className="text-xs font-semibold tracking-wider uppercase text-text-primary">
-          Output
-        </span>
-      </div>
-      <div className="flex items-end justify-center gap-4 px-3 py-3 mt-auto">
-        <Knob
-          label="Low"
-          value={params.lowGain}
-          onChange={(v) => updateParams({ lowGain: v })}
-          color="#c45e3e"
-          min={0}
-          max={2}
-          displayValue={`${(params.lowGain * 100).toFixed(0)}%`}
-        />
-        <Knob
-          label="High"
-          value={params.highGain}
-          onChange={(v) => updateParams({ highGain: v })}
-          color="#8ab4c4"
-          min={0}
-          max={2}
-          displayValue={`${(params.highGain * 100).toFixed(0)}%`}
-        />
-        <Knob
-          label="Dry/Wet"
-          value={params.dryWet}
-          onChange={(v) => updateParams({ dryWet: v })}
-          color="#3eafc4"
-          displayValue={`${Math.round(params.dryWet * 100)}%`}
-        />
-        <Knob
-          label="Output"
-          value={params.masterGain}
-          onChange={(v) => updateParams({ masterGain: v })}
-          color="#3eafc4"
-          min={0}
-          max={2}
-          displayValue={`${(params.masterGain * 100).toFixed(0)}%`}
+      <div className="flex items-center gap-2 px-3 py-2 border-b" style={{ borderColor: `${color}30` }}>
+        {number && <span className="text-[10px]" style={{ color }}>{number}</span>}
+        <span className="text-xs font-semibold tracking-wider uppercase text-text-primary">{title}</span>
+        <div className="flex-1" />
+        <button
+          onClick={onToggle}
+          className="w-4 h-4 rounded-full border-2"
+          style={{ borderColor: color, background: enabled ? color : 'transparent' }}
         />
       </div>
+      <div className="px-3 py-3 flex flex-col gap-2">{children}</div>
     </div>
   );
 }
@@ -87,128 +64,17 @@ export default function App() {
     engine,
     isPlaying,
     fileName,
-    duration,
-    currentTime,
     params,
-    retuneStatus,
     init,
     loadFile,
     togglePlay,
     stop,
-    restart,
-    seek,
     updateParams,
   } = useAudioEngine();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [specWidth, setSpecWidth] = useState(1100);
-  const specHeight = 320;
-  const [selectedBand, setSelectedBand] = useState<number | null>(null);
-  const [showDevPanel, setShowDevPanel] = useState(false);
 
-  // --- Dynamic FX slots (default: Saturate → Retune → Saturate 2) ---
-  const [fxSlots, setFxSlots] = useState<FxSlot[]>([
-    { id: crypto.randomUUID(), type: 'saturate' },
-    { id: crypto.randomUUID(), type: 'retune' },
-    { id: crypto.randomUUID(), type: 'saturate2' },
-    { id: crypto.randomUUID(), type: 'sub' },
-  ]);
-
-  const addFxSlot = useCallback((type: FxType) => {
-    if (SINGLETON_FX.includes(type) && fxSlots.some(slot => slot.type === type)) {
-      return;
-    }
-    const newId = crypto.randomUUID();
-    setFxSlots(prev => [...prev, { id: newId, type }]);
-    if (type === 'peq') {
-      updateParams({
-        peqInstances: [...params.peqInstances, {
-          id: newId,
-          enabled: true,
-          mode: 'cut',
-          key: params.retuneKey,
-          scale: params.retuneScale,
-          amount: 0.5,
-          q: 5.0,
-        }],
-      });
-    }
-  }, [fxSlots, params.peqInstances, params.retuneKey, params.retuneScale, updateParams]);
-
-  const removeFxSlot = useCallback((id: string) => {
-    const slot = fxSlots.find(s => s.id === id);
-    if (!slot) return;
-
-    setFxSlots(prev => prev.filter(s => s.id !== id));
-
-    if (slot.type === 'peq') {
-      updateParams({
-        peqInstances: params.peqInstances.filter(inst => inst.id !== id),
-      });
-      return;
-    }
-
-    switch (slot.type) {
-      case 'saturate':
-        updateParams({ saturateEnabled: false });
-        break;
-      case 'retune':
-        updateParams({ retuneEnabled: false });
-        break;
-      case 'delay':
-        updateParams({ delayEnabled: false });
-        break;
-      case 'modulate':
-        updateParams({ modEnabled: false });
-        break;
-      case 'lofi':
-        updateParams({ lofiEnabled: false });
-        break;
-      case 'saturate2':
-        updateParams({ saturate2Enabled: false });
-        break;
-      case 'sub':
-        updateParams({ subEnabled: false });
-        break;
-    }
-  }, [fxSlots, params.peqInstances, updateParams]);
-
-  const orderedFxSlots = [...fxSlots].sort(
-    (a, b) => FX_ORDER.indexOf(a.type) - FX_ORDER.indexOf(b.type)
-  );
-
-  const availableFxTypes = (Object.keys(FX_CATALOG) as FxType[]).filter((type) => (
-    type === 'peq' || !orderedFxSlots.some((slot) => slot.type === type)
-  ));
-
-  // --- Keyboard shortcuts ---
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Ignore if user is typing in an input
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-
-      // Dev panel toggle works without a file loaded
-      if (e.code === 'KeyD' && e.shiftKey && !e.metaKey && !e.ctrlKey) {
-        e.preventDefault();
-        setShowDevPanel(prev => !prev);
-        return;
-      }
-
-      if (!fileName) return;
-
-      if (e.code === 'Space') {
-        e.preventDefault();
-        togglePlay();
-      } else if (e.code === 'KeyR' && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
-        e.preventDefault();
-        restart();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [togglePlay, restart, fileName]);
-
-  // Resize observer for spectrum width
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -222,7 +88,6 @@ export default function App() {
   }, []);
 
   const handleOpenFile = useCallback(async () => {
-    // Ensure audio context is initialized (requires user gesture)
     await init();
 
     if (window.electronAPI) {
@@ -230,295 +95,22 @@ export default function App() {
       if (result) {
         await loadFile(result.buffer, result.name);
       }
-    } else {
-      // Fallback: browser file input
-      const input = document.createElement('input');
-      input.type = 'file';
-      input.accept = 'audio/*';
-      input.onchange = async () => {
-        const file = input.files?.[0];
-        if (!file) return;
-        const buffer = await file.arrayBuffer();
-        await loadFile(buffer, file.name);
-      };
-      input.click();
+      return;
     }
+
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'audio/*';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      await loadFile(await file.arrayBuffer(), file.name);
+    };
+    input.click();
   }, [init, loadFile]);
-
-  const handleBandChange = useCallback((index: number, changes: Partial<EQBand>) => {
-    setSelectedBand(index);
-    const newBands = [...params.eqBands];
-    newBands[index] = { ...newBands[index], ...changes };
-    updateParams({ eqBands: newBands });
-  }, [params.eqBands, updateParams]);
-
-  const handleShapeChange = useCallback((type: FilterType) => {
-    if (selectedBand === null) return;
-    const newBands = [...params.eqBands];
-    newBands[selectedBand] = { ...newBands[selectedBand], type };
-    updateParams({ eqBands: newBands });
-  }, [selectedBand, params.eqBands, updateParams]);
-
-  // --- Render an FX slot as the correct EffectModule ---
-  function renderFxSlot(slot: FxSlot) {
-    const meta = FX_CATALOG[slot.type];
-
-    switch (slot.type) {
-      case 'saturate':
-        return (
-          <EffectModule
-            key={slot.id}
-            title={meta.label}
-            color={meta.color}
-            enabled={params.saturateEnabled}
-            onToggle={() => updateParams({ saturateEnabled: !params.saturateEnabled })}
-            onRemove={() => removeFxSlot(slot.id)}
-            subtitle={params.saturateType}
-            subtitleOptions={['tape', 'tube', 'wavefold']}
-            onSubtitleChange={(v) => updateParams({ saturateType: v as 'tape' | 'tube' | 'wavefold' })}
-          >
-            <Knob
-              label="Drive"
-              value={params.saturateDrive}
-              onChange={(v) => updateParams({ saturateDrive: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.saturateDrive * 100)}%`}
-            />
-            <Knob
-              label="Tilt"
-              value={params.saturateTilt}
-              onChange={(v) => updateParams({ saturateTilt: v })}
-              color={meta.color}
-              displayValue={`${((params.saturateTilt - 0.5) * 100).toFixed(0)}`}
-            />
-          </EffectModule>
-        );
-
-      case 'saturate2':
-        return (
-          <EffectModule
-            key={slot.id}
-            title={meta.label}
-            color={meta.color}
-            enabled={params.saturate2Enabled}
-            onToggle={() => updateParams({ saturate2Enabled: !params.saturate2Enabled })}
-            onRemove={() => removeFxSlot(slot.id)}
-            subtitle={params.saturate2Type}
-            subtitleOptions={['tape', 'tube', 'wavefold']}
-            onSubtitleChange={(v) => updateParams({ saturate2Type: v as 'tape' | 'tube' | 'wavefold' })}
-          >
-            <Knob
-              label="Drive"
-              value={params.saturate2Drive}
-              onChange={(v) => updateParams({ saturate2Drive: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.saturate2Drive * 100)}%`}
-            />
-            <Knob
-              label="Tilt"
-              value={params.saturate2Tilt}
-              onChange={(v) => updateParams({ saturate2Tilt: v })}
-              color={meta.color}
-              displayValue={`${((params.saturate2Tilt - 0.5) * 100).toFixed(0)}`}
-            />
-          </EffectModule>
-        );
-
-      case 'sub':
-        return (
-          <EffectModule
-            key={slot.id}
-            title={meta.label}
-            color={meta.color}
-            enabled={params.subEnabled}
-            onToggle={() => updateParams({ subEnabled: !params.subEnabled })}
-            onRemove={() => removeFxSlot(slot.id)}
-            subtitle={retuneStatus?.lowEndLocked ? 'Locked' : 'Waiting'}
-          >
-            <Knob
-              label="Level"
-              value={params.subLevel}
-              onChange={(v) => updateParams({ subLevel: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.subLevel * 100)}%`}
-            />
-          </EffectModule>
-        );
-
-      case 'retune':
-        return (
-          <RetuneModule
-            key={slot.id}
-            color={meta.color}
-            params={params}
-            status={retuneStatus}
-            updateParams={updateParams}
-            onRemove={() => removeFxSlot(slot.id)}
-          />
-        );
-
-      case 'delay':
-        return (
-          <EffectModule
-            key={slot.id}
-            title={meta.label}
-            color={meta.color}
-            enabled={params.delayEnabled}
-            onToggle={() => updateParams({ delayEnabled: !params.delayEnabled })}
-            onRemove={() => removeFxSlot(slot.id)}
-            subtitle="Classic"
-          >
-            <Knob
-              label="Time"
-              value={params.delayTime}
-              onChange={(v) => updateParams({ delayTime: v })}
-              color={meta.color}
-              min={0.01}
-              max={1.0}
-              displayValue={`${Math.round(params.delayTime * 1000)}ms`}
-            />
-            <Knob
-              label="Feedback"
-              value={params.delayFeedback}
-              onChange={(v) => updateParams({ delayFeedback: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.delayFeedback * 100)}%`}
-            />
-          </EffectModule>
-        );
-
-      case 'modulate':
-        return (
-          <EffectModule
-            key={slot.id}
-            title={meta.label}
-            color={meta.color}
-            enabled={params.modEnabled}
-            onToggle={() => updateParams({ modEnabled: !params.modEnabled })}
-            onRemove={() => removeFxSlot(slot.id)}
-            subtitle="Chorus"
-          >
-            <Knob
-              label="Depth"
-              value={params.modDepth}
-              onChange={(v) => updateParams({ modDepth: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.modDepth * 100)}%`}
-            />
-            <Knob
-              label="Rate"
-              value={params.modRate}
-              onChange={(v) => updateParams({ modRate: v })}
-              color={meta.color}
-              min={0.1}
-              max={10}
-              displayValue={`${params.modRate.toFixed(1)} Hz`}
-            />
-          </EffectModule>
-        );
-
-      case 'lofi':
-        return (
-          <EffectModule
-            key={slot.id}
-            title={meta.label}
-            color={meta.color}
-            enabled={params.lofiEnabled}
-            onToggle={() => updateParams({ lofiEnabled: !params.lofiEnabled })}
-            onRemove={() => removeFxSlot(slot.id)}
-            subtitle="Cassette"
-          >
-            <Knob
-              label="Wear"
-              value={params.lofiWear}
-              onChange={(v) => updateParams({ lofiWear: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.lofiWear * 100)}%`}
-            />
-            <Knob
-              label="Wobble"
-              value={params.lofiWobble}
-              onChange={(v) => updateParams({ lofiWobble: v })}
-              color={meta.color}
-              displayValue={`${Math.round(params.lofiWobble * 100)}%`}
-            />
-          </EffectModule>
-        );
-
-      case 'peq':
-        {
-        const peqNoteNames = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
-        const inst = params.peqInstances.find(p => p.id === slot.id);
-        if (!inst) return null;
-        const instIdx = params.peqInstances.indexOf(inst);
-        const updatePeq = (changes: Partial<PeqInstance>) => {
-          const updated = [...params.peqInstances];
-          updated[instIdx] = { ...updated[instIdx], ...changes };
-          updateParams({ peqInstances: updated });
-        };
-        return (
-          <EffectModule
-            key={slot.id}
-            title={meta.label}
-            color={meta.color}
-            enabled={inst.enabled}
-            onToggle={() => updatePeq({ enabled: !inst.enabled })}
-            onRemove={() => removeFxSlot(slot.id)}
-            subtitle={inst.scale}
-            subtitleOptions={['major', 'minor', 'pentatonic', 'dorian', 'mixolydian', 'harmonic_minor']}
-            onSubtitleChange={(v) => updatePeq({ scale: v })}
-          >
-            <button
-              onClick={() => updatePeq({ mode: inst.mode === 'boost' ? 'cut' : 'boost' })}
-              className="flex flex-col items-center justify-center rounded-lg px-2 py-1 transition-colors"
-              style={{
-                background: inst.mode === 'boost' ? '#5ec4b830' : '#c45e3e30',
-                border: `1px solid ${inst.mode === 'boost' ? '#5ec4b860' : '#c45e3e60'}`,
-                minWidth: 42,
-              }}
-              title={inst.mode === 'boost' ? 'Boosting in-key frequencies' : 'Cutting out-of-key frequencies'}
-            >
-              <span className="text-lg font-bold" style={{ color: inst.mode === 'boost' ? '#5ec4b8' : '#c45e3e' }}>
-                {inst.mode === 'boost' ? '(+)' : '(−)'}
-              </span>
-              <span className="text-[9px] uppercase tracking-wider" style={{ color: inst.mode === 'boost' ? '#5ec4b8' : '#c45e3e' }}>
-                {inst.mode === 'boost' ? 'Boost' : 'Cut'}
-              </span>
-            </button>
-            <Knob
-              label="Key"
-              value={inst.key}
-              onChange={(v) => updatePeq({ key: Math.round(v) })}
-              color={meta.color}
-              min={0}
-              max={11}
-              displayValue={peqNoteNames[Math.round(inst.key)]}
-            />
-            <Knob
-              label="Amount"
-              value={inst.amount}
-              onChange={(v) => updatePeq({ amount: v })}
-              color={meta.color}
-              displayValue={`${Math.round(inst.amount * 100)}%`}
-            />
-            <Knob
-              label="Q"
-              value={inst.q}
-              onChange={(v) => updatePeq({ q: v })}
-              color={meta.color}
-              min={0.5}
-              max={12}
-              displayValue={inst.q.toFixed(1)}
-            />
-          </EffectModule>
-        );
-        }
-    }
-  }
 
   return (
     <div className="h-screen flex flex-col bg-surface-0">
-      {/* Top Toolbar */}
       <Toolbar
         bypass={params.bypass}
         onBypassToggle={() => updateParams({ bypass: !params.bypass })}
@@ -526,63 +118,117 @@ export default function App() {
         fileName={fileName}
         isPlaying={isPlaying}
         onTogglePlay={togglePlay}
-        onStop={() => { stop(); seek(0); }}
-        currentTime={currentTime}
-        duration={duration}
-        onSeek={seek}
+        onStop={() => stop()}
       />
 
-      {/* Spectrum Display */}
-      <div ref={containerRef} className="flex-1 min-h-0 px-2 py-1">
+      <div ref={containerRef} className="px-2 pt-2">
         <SpectrumAnalyzer
           analyser={engine?.getAnalyser() ?? null}
           eqBands={params.eqBands}
-          retuneStatus={retuneStatus}
-          retuneEnabled={params.retuneEnabled}
-          retuneKey={params.retuneKey}
-          retuneScale={params.retuneScale}
-          onBandChange={handleBandChange}
+          onBandChange={(index, band) => {
+            const newBands = [...params.eqBands];
+            newBands[index] = { ...newBands[index], ...band };
+            updateParams({ eqBands: newBands });
+          }}
           width={specWidth}
-          height={specHeight}
+          height={350}
+          retuneBandStartHz={200}
+          retuneBandEndHz={5000}
+          retuneBandColor="#4891ff"
         />
       </div>
 
-      {/* Info Bar */}
-      <InfoBar
-        selectedBand={selectedBand}
-        eqBands={params.eqBands}
-        onShapeChange={handleShapeChange}
-      />
-
-      {/* Dev Panel (Shift+D to toggle) */}
-      {showDevPanel && (
-        <div
-          className="flex items-center gap-4 px-4 py-2 mx-2 rounded-lg"
-          style={{
-            background: '#1a1a2e',
-            border: '1px solid #ff6b3540',
-          }}
-        >
-          <span className="text-xs font-mono text-yellow-400 uppercase tracking-wider">Dev</span>
-          <Knob
-            label="Drive Range"
-            value={params._devDriveRange}
-            onChange={(v) => updateParams({ _devDriveRange: v })}
-            color="#ff6b35"
-            displayValue={`${(params._devDriveRange * 100).toFixed(0)}%`}
-          />
-          <span className="text-xs text-gray-500 font-mono">
-            Tape max: {(1 + 20 * params._devDriveRange).toFixed(0)}x |
-            Tube max: {(1 + 25 * params._devDriveRange).toFixed(0)}x
-          </span>
-        </div>
-      )}
-
-      {/* Effect Modules Row */}
       <div className="flex gap-2 px-2 py-3 overflow-x-auto items-start">
-        {orderedFxSlots.map(slot => renderFxSlot(slot))}
-        <AddFxButton onAdd={addFxSlot} availableTypes={availableFxTypes} />
-        <OutputModule params={params} updateParams={updateParams} />
+        <ModuleShell
+          number="1"
+          title="Primary Saturator"
+          color="#d88b52"
+          enabled={params.saturateEnabled}
+          onToggle={() => updateParams({ saturateEnabled: !params.saturateEnabled })}
+          minWidth={190}
+        >
+          <select
+            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
+            value={params.saturateType === 'wavefold' ? 'Foldback' : params.saturateType === 'tube' ? 'Tube' : 'Analog Tape'}
+            onChange={(e) => {
+              const val = e.target.value;
+              updateParams({ saturateType: val === 'Tube' ? 'tube' : val === 'Foldback' ? 'wavefold' : 'tape' });
+            }}
+          >
+            {SAT_TYPES.map((type) => <option key={type}>{type}</option>)}
+          </select>
+          <select value={params.saturateSoftness} onChange={(e) => updateParams({ saturateSoftness: e.target.value as 'soft' | 'medium' | 'hard' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
+            {SOFTNESS.map((softness) => <option key={softness} value={softness.toLowerCase()}>{softness}</option>)}
+          </select>
+          <div className="flex flex-col items-center gap-2">
+            <Knob label="Drive" value={params.saturateDrive} onChange={(v) => updateParams({ saturateDrive: v })} color="#d88b52" displayValue={`${Math.round(params.saturateDrive * 100)}%`} />
+            <Knob label="Tone" value={params.saturateTilt} onChange={(v) => updateParams({ saturateTilt: v })} color="#d88b52" displayValue={`${Math.round((params.saturateTilt - 0.5) * 200)}`} />
+            <Knob label="Mix" value={params.saturateMix} onChange={(v) => updateParams({ saturateMix: v })} color="#d88b52" displayValue={`${Math.round(params.saturateMix * 100)}%`} />
+          </div>
+        </ModuleShell>
+
+        <RetuneModule color="#4891ff" params={params} updateParams={updateParams} />
+
+        <ModuleShell
+          number="3"
+          title="Secondary Saturator"
+          color="#9d6ee9"
+          enabled={params.saturate2Enabled}
+          onToggle={() => updateParams({ saturate2Enabled: !params.saturate2Enabled })}
+          minWidth={190}
+        >
+          <select
+            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
+            value={params.saturate2Type === 'wavefold' ? 'Foldback' : params.saturate2Type === 'tube' ? 'Tube' : 'Analog Tape'}
+            onChange={(e) => {
+              const val = e.target.value;
+              updateParams({ saturate2Type: val === 'Tube' ? 'tube' : val === 'Foldback' ? 'wavefold' : 'tape' });
+            }}
+          >
+            {SAT_TYPES.map((type) => <option key={type}>{type}</option>)}
+          </select>
+          <select value={params.saturate2Softness} onChange={(e) => updateParams({ saturate2Softness: e.target.value as 'soft' | 'medium' | 'hard' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
+            {SOFTNESS.map((softness) => <option key={softness} value={softness.toLowerCase()}>{softness}</option>)}
+          </select>
+          <div className="flex flex-col items-center gap-2">
+            <Knob label="Drive" value={params.saturate2Drive} onChange={(v) => updateParams({ saturate2Drive: v })} color="#9d6ee9" displayValue={`${Math.round(params.saturate2Drive * 100)}%`} />
+            <Knob label="Tone" value={params.saturate2Tilt} onChange={(v) => updateParams({ saturate2Tilt: v })} color="#9d6ee9" displayValue={`${Math.round((params.saturate2Tilt - 0.5) * 200)}`} />
+            <Knob label="Mix" value={params.saturate2Mix} onChange={(v) => updateParams({ saturate2Mix: v })} color="#9d6ee9" displayValue={`${Math.round(params.saturate2Mix * 100)}%`} />
+          </div>
+        </ModuleShell>
+
+        <ModuleShell
+          title="Sub Generator"
+          color="#34c7cf"
+          enabled={params.subEnabled}
+          onToggle={() => updateParams({ subEnabled: !params.subEnabled })}
+          minWidth={220}
+        >
+          <select value={params.subRootNote} onChange={(e) => updateParams({ subRootNote: Number(e.target.value) })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
+            {NOTE_OPTIONS.map((note, i) => <option key={note} value={i}>{note}</option>)}
+          </select>
+          <select value={params.subOctave} onChange={(e) => updateParams({ subOctave: Number(e.target.value) as -2 | -1 | 0 })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
+            <option value={-2}>-2</option><option value={-1}>-1</option><option value={0}>0</option>
+          </select>
+          <select value={params.subWaveform} onChange={(e) => updateParams({ subWaveform: e.target.value as 'sine' | 'triangle' | 'rounded_square' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
+            <option value="sine">Sine</option><option value="triangle">Triangle</option><option value="rounded_square">Rounded Square</option>
+          </select>
+          <div className="flex justify-center">
+            <Knob label="Level" value={params.subLevel} onChange={(v) => updateParams({ subLevel: v })} color="#34c7cf" displayValue={`${Math.round(params.subLevel * 100)}%`} />
+          </div>
+        </ModuleShell>
+
+        <ModuleShell title="Output" color="#3eafc4" enabled={true} onToggle={() => undefined} minWidth={240}>
+          <div className="grid grid-cols-2 gap-2 justify-items-center">
+            <Knob label="Low" value={params.lowGain} onChange={(v) => updateParams({ lowGain: v })} color="#d88b52" min={0} max={2} displayValue={`${(params.lowGain * 100).toFixed(0)}%`} />
+            <Knob label="High" value={params.highGain} onChange={(v) => updateParams({ highGain: v })} color="#4891ff" min={0} max={2} displayValue={`${(params.highGain * 100).toFixed(0)}%`} />
+            <Knob label="Dry/Wet" value={params.dryWet} onChange={(v) => updateParams({ dryWet: v })} color="#3eafc4" displayValue={`${Math.round(params.dryWet * 100)}%`} />
+            <Knob label="Gain" value={params.masterGain} onChange={(v) => updateParams({ masterGain: v })} color="#3eafc4" min={0} max={2} displayValue={`${(params.masterGain * 100).toFixed(0)}%`} />
+          </div>
+          <select value={params.outputLimiterType} onChange={(e) => updateParams({ outputLimiterType: e.target.value as 'transparent' | 'soft' | 'hard' | 'off' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary mt-1">
+            <option value="transparent">Transparent</option><option value="soft">Soft</option><option value="hard">Hard</option><option value="off">Off</option>
+          </select>
+        </ModuleShell>
       </div>
     </div>
   );

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -36,22 +36,30 @@ function ModuleShell({
 }) {
   return (
     <div
-      className="flex flex-col rounded-xl overflow-hidden flex-shrink-0"
+      className="flex flex-col rounded-xl overflow-hidden flex-shrink-0 backdrop-blur-[1px]"
       style={{
-        background: `linear-gradient(180deg, ${color}16 0%, #14142b 100%)`,
-        border: `1px solid ${color}4a`,
+        background: `linear-gradient(180deg, #11182d 0%, #0f1324 100%)`,
+        border: `1px solid ${color}33`,
         minWidth,
         opacity: enabled ? 1 : 0.6,
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.02)',
       }}
     >
-      <div className="flex items-center gap-2 px-3 py-2 border-b" style={{ borderColor: `${color}30` }}>
-        {number && <span className="text-[10px]" style={{ color }}>{number}</span>}
+      <div className="flex items-center gap-2 px-3 py-2 border-b" style={{ borderColor: '#23314d' }}>
+        {number && (
+          <span
+            className="w-[18px] h-[18px] rounded-full text-[10px] font-semibold flex items-center justify-center"
+            style={{ background: `${color}2a`, color }}
+          >
+            {number}
+          </span>
+        )}
         <span className="text-xs font-semibold tracking-wider uppercase text-text-primary">{title}</span>
         <div className="flex-1" />
         <button
           onClick={onToggle}
-          className="w-4 h-4 rounded-full border-2"
-          style={{ borderColor: color, background: enabled ? color : 'transparent' }}
+          className="w-4 h-4 rounded-full border"
+          style={{ borderColor: color, background: enabled ? `${color}22` : 'transparent' }}
         />
       </div>
       <div className="px-3 py-3 flex flex-col gap-2">{children}</div>
@@ -138,7 +146,7 @@ export default function App() {
         />
       </div>
 
-      <div className="flex gap-2 px-2 py-3 overflow-x-auto items-start">
+      <div className="flex gap-2 px-2 py-3 overflow-x-auto items-stretch">
         <ModuleShell
           number="1"
           title="Primary Saturator"
@@ -198,7 +206,7 @@ export default function App() {
         </ModuleShell>
 
         <ModuleShell
-          title="Sub Generator"
+          title="Sub (Unquantized)"
           color="#34c7cf"
           enabled={params.subEnabled}
           onToggle={() => updateParams({ subEnabled: !params.subEnabled })}
@@ -218,12 +226,14 @@ export default function App() {
           </div>
         </ModuleShell>
 
-        <ModuleShell title="Output" color="#3eafc4" enabled={true} onToggle={() => undefined} minWidth={240}>
+        <ModuleShell title="Output" color="#3eafc4" enabled={true} onToggle={() => undefined} minWidth={260}>
           <div className="grid grid-cols-2 gap-2 justify-items-center">
             <Knob label="Low" value={params.lowGain} onChange={(v) => updateParams({ lowGain: v })} color="#d88b52" min={0} max={2} displayValue={`${(params.lowGain * 100).toFixed(0)}%`} />
             <Knob label="High" value={params.highGain} onChange={(v) => updateParams({ highGain: v })} color="#4891ff" min={0} max={2} displayValue={`${(params.highGain * 100).toFixed(0)}%`} />
             <Knob label="Dry/Wet" value={params.dryWet} onChange={(v) => updateParams({ dryWet: v })} color="#3eafc4" displayValue={`${Math.round(params.dryWet * 100)}%`} />
-            <Knob label="Gain" value={params.masterGain} onChange={(v) => updateParams({ masterGain: v })} color="#3eafc4" min={0} max={2} displayValue={`${(params.masterGain * 100).toFixed(0)}%`} />
+            <div className="flex flex-col items-center">
+              <Knob label="Gain" value={params.masterGain} onChange={(v) => updateParams({ masterGain: v })} color="#3eafc4" min={0} max={2} size={68} displayValue={`${(params.masterGain * 100).toFixed(0)}%`} />
+            </div>
           </div>
           <select value={params.outputLimiterType} onChange={(e) => updateParams({ outputLimiterType: e.target.value as 'transparent' | 'soft' | 'hard' | 'off' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary mt-1">
             <option value="transparent">Transparent</option><option value="soft">Soft</option><option value="hard">Hard</option><option value="off">Off</option>

--- a/ui/src/audio/engine.ts
+++ b/ui/src/audio/engine.ts
@@ -58,12 +58,12 @@ export interface RetuneStatus {
 
 export const FX_CATALOG: Record<FxType, { label: string; color: string }> = {
   saturate:  { label: 'Saturate',   color: '#c45e3e' },
-  retune:    { label: 'Retune',     color: '#4ec48a' },
+  retune:    { label: 'Retune',     color: '#4891ff' },
   delay:     { label: 'Delay',      color: '#3eafc4' },
   modulate:  { label: 'Modulate',   color: '#8a5ec4' },
   lofi:      { label: 'Lo-Fi',      color: '#8a7e5e' },
   saturate2: { label: 'Saturate 2', color: '#d47a5e' },
-  sub:       { label: 'Sub',        color: '#6ea8ff' },
+  sub:       { label: 'Sub',        color: '#34c7cf' },
   peq:       { label: 'Param EQ',   color: '#5ec4b8' },
 };
 
@@ -76,11 +76,15 @@ export interface EngineParams {
   saturateType: 'tape' | 'tube' | 'wavefold';
   saturateDrive: number;
   saturateTilt: number;
+  saturateSoftness: 'soft' | 'medium' | 'hard';
+  saturateMix: number;
 
   saturate2Enabled: boolean;
   saturate2Type: 'tape' | 'tube' | 'wavefold';
   saturate2Drive: number;
   saturate2Tilt: number;
+  saturate2Softness: 'soft' | 'medium' | 'hard';
+  saturate2Mix: number;
 
   retuneEnabled: boolean;
   retuneMode: RetuneMode;
@@ -101,9 +105,13 @@ export interface EngineParams {
 
   subEnabled: boolean;
   subLevel: number;
+  subRootNote: number;
+  subOctave: -2 | -1 | 0;
+  subWaveform: 'sine' | 'triangle' | 'rounded_square';
 
   lowGain: number;
   highGain: number;
+  outputLimiterType: 'transparent' | 'soft' | 'hard' | 'off';
 
   _devDriveRange: number;
 
@@ -134,11 +142,15 @@ export const DEFAULT_PARAMS: EngineParams = {
   saturateType: 'tape',
   saturateDrive: 0.3,
   saturateTilt: 0.5,
+  saturateSoftness: 'medium',
+  saturateMix: 0.8,
 
   saturate2Enabled: true,
   saturate2Type: 'tape',
   saturate2Drive: 0.5,
   saturate2Tilt: 0.5,
+  saturate2Softness: 'medium',
+  saturate2Mix: 0.75,
 
   retuneEnabled: false,
   retuneMode: 'polyphonic',
@@ -159,9 +171,13 @@ export const DEFAULT_PARAMS: EngineParams = {
 
   subEnabled: true,
   subLevel: 0.25,
+  subRootNote: 0,
+  subOctave: -1,
+  subWaveform: 'sine',
 
   lowGain: 1.0,
   highGain: 1.0,
+  outputLimiterType: 'transparent',
 
   _devDriveRange: 0.4,
 

--- a/ui/src/components/RetuneModule.tsx
+++ b/ui/src/components/RetuneModule.tsx
@@ -1,311 +1,126 @@
-import { EffectModule } from './EffectModule';
 import { Knob } from './Knob';
-import type { EngineParams, RetuneStatus } from '../audio/engine';
-import { NOTE_NAMES, RETUNE_SCALES, buildScaleMask } from '../audio/retune';
+import type { EngineParams } from '../audio/engine';
+import { NOTE_NAMES } from '../audio/retune';
 
 interface RetuneModuleProps {
   color: string;
   params: EngineParams;
-  status: RetuneStatus | null;
   updateParams: (patch: Partial<EngineParams>) => void;
-  onRemove: () => void;
 }
 
-const SCALE_OPTIONS = Object.keys(RETUNE_SCALES) as Array<keyof typeof RETUNE_SCALES>;
-const OUT_OF_MASK_MODES: EngineParams['retuneOutOfMaskMode'][] = ['nearest', 'preserve', 'mute'];
+const SCALE_OPTIONS: EngineParams['retuneScale'][] = [
+  'major',
+  'minor',
+  'dorian',
+  'phrygian',
+  'lydian',
+  'mixolydian',
+  'aeolian',
+  'harmonic_minor',
+  'custom',
+];
 
-function formatScaleLabel(scale: string) {
-  return scale.replace('_', ' ');
-}
+const QUANTIZE_MODES = ['snap', 'glide', 'preserve attacks'] as const;
 
-function CycleControl({
-  label,
-  value,
-  onPrev,
-  onNext,
-}: {
-  label: string;
-  value: string;
-  onPrev: () => void;
-  onNext: () => void;
-}) {
-  return (
-    <div className="flex items-center gap-2 rounded-lg border border-border bg-surface-1/80 px-2.5 py-2">
-      <span className="text-[10px] uppercase tracking-[0.24em] text-text-dim">{label}</span>
-      <button
-        onClick={onPrev}
-        className="text-text-dim transition-colors hover:text-text-primary"
-        aria-label={`Previous ${label}`}
-      >
-        &#9664;
-      </button>
-      <span className="min-w-[60px] text-center text-xs font-medium capitalize text-text-primary">
-        {value}
-      </span>
-      <button
-        onClick={onNext}
-        className="text-text-dim transition-colors hover:text-text-primary"
-        aria-label={`Next ${label}`}
-      >
-        &#9654;
-      </button>
-    </div>
-  );
-}
-
-export function RetuneModule({
-  color,
-  params,
-  status,
-  updateParams,
-  onRemove,
-}: RetuneModuleProps) {
-  const targetMask = params.retuneTargetMask.length === 12
-    ? params.retuneTargetMask
-    : buildScaleMask(params.retuneKey, params.retuneScale);
-  const scaleIndex = SCALE_OPTIONS.indexOf(params.retuneScale);
-
-  const stateLabel = !params.retuneEnabled
-    ? 'Off'
-    : status?.overloaded
-      ? 'Overloaded'
-      : status?.noteCount
-        ? 'Tracking'
-        : 'Listening';
-
-  const handleKeyChange = (key: number) => {
-    updateParams({
-      retuneKey: key,
-      ...(params.retuneUseCustomMask
-        ? {}
-        : { retuneTargetMask: buildScaleMask(key, params.retuneScale) }),
-    });
-  };
-
-  const handleScaleChange = (scale: EngineParams['retuneScale']) => {
-    updateParams({
-      retuneScale: scale,
-      ...(params.retuneUseCustomMask
-        ? {}
-        : { retuneTargetMask: buildScaleMask(params.retuneKey, scale) }),
-    });
-  };
-
-  const handleMaskToggle = (pitchClass: number) => {
-    const nextMask = [...targetMask];
-    const enabledCount = nextMask.filter(Boolean).length;
-    if (nextMask[pitchClass] && enabledCount === 1) {
-      return;
-    }
-    nextMask[pitchClass] = !nextMask[pitchClass];
-    updateParams({ retuneTargetMask: nextMask });
-  };
-
-  const toggleCustomMask = () => {
-    if (params.retuneUseCustomMask) {
-      updateParams({
-        retuneUseCustomMask: false,
-        retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale),
-      });
-      return;
-    }
-
-    updateParams({ retuneUseCustomMask: true });
-  };
+export function RetuneModule({ color, params, updateParams }: RetuneModuleProps) {
+  const quantizeMode = params.retunePreserveTransients ? 'preserve attacks' : (params.retuneOutOfMaskMode === 'preserve' ? 'glide' : 'snap');
 
   return (
-    <EffectModule
-      title="Retune"
-      color={color}
-      enabled={params.retuneEnabled}
-      onToggle={() => updateParams({ retuneEnabled: !params.retuneEnabled })}
-      onRemove={onRemove}
-      minWidth={500}
-      controlsClassName="flex flex-col gap-3 px-3 py-3"
+    <div
+      className="flex flex-col rounded-xl overflow-hidden flex-shrink-0"
+      style={{
+        background: 'linear-gradient(180deg, #4891ff16 0%, #14142b 100%)',
+        border: '1px solid #4891ff55',
+        minWidth: 250,
+      }}
     >
-      <div className="rounded-lg border border-border bg-surface-2/60 px-3 py-2.5">
-        <div className="flex flex-wrap items-center gap-2 text-[11px]">
-          <span className="rounded-full border border-border bg-surface-1/80 px-2.5 py-1 uppercase tracking-[0.24em] text-text-dim">
-            {stateLabel}
-          </span>
-          <span className="text-text-secondary">
-            {status ? `${status.noteCount} groups · ${Math.round(status.confidence * 100)}% conf` : 'Waiting for engine'}
-          </span>
-          {status?.lowEndLocked && (
-            <span className="rounded-full bg-[#4ec48a22] px-2 py-1 text-[#9ce0b8]">
-              Low End Locked
-            </span>
-          )}
-          {status?.transientBypassActive && (
-            <span className="rounded-full bg-surface-1 px-2 py-1 text-text-secondary">
-              Preserve Attacks Active
-            </span>
-          )}
-          <div className="ml-auto text-[11px] text-text-dim">
-            Live note routes are shown in the spectrum.
-          </div>
-        </div>
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <CycleControl
-            label="Key"
-            value={NOTE_NAMES[Math.round(params.retuneKey)]}
-            onPrev={() => handleKeyChange((Math.round(params.retuneKey) + 11) % 12)}
-            onNext={() => handleKeyChange((Math.round(params.retuneKey) + 1) % 12)}
-          />
-          <CycleControl
-            label="Scale"
-            value={formatScaleLabel(params.retuneScale)}
-            onPrev={() => handleScaleChange(SCALE_OPTIONS[(scaleIndex - 1 + SCALE_OPTIONS.length) % SCALE_OPTIONS.length])}
-            onNext={() => handleScaleChange(SCALE_OPTIONS[(scaleIndex + 1) % SCALE_OPTIONS.length])}
-          />
-          <button
-            onClick={toggleCustomMask}
-            className="rounded-lg border px-3 py-2 text-[11px] uppercase tracking-[0.2em] transition-colors"
-            style={{
-              background: params.retuneUseCustomMask ? `${color}22` : '#14142b',
-              borderColor: params.retuneUseCustomMask ? `${color}66` : '#3a3a5c',
-              color: params.retuneUseCustomMask ? '#e8e8f0' : '#8888a8',
-            }}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-[#4891ff33]">
+        <span className="text-[10px] text-[#9dbfff]">2</span>
+        <span className="text-xs font-semibold tracking-wider uppercase text-text-primary">Retune</span>
+        <div className="flex-1" />
+        <button
+          onClick={() => updateParams({ retuneEnabled: !params.retuneEnabled })}
+          className="w-4 h-4 rounded-full border-2"
+          style={{ borderColor: color, background: params.retuneEnabled ? color : 'transparent' }}
+          aria-label="Toggle retune"
+        />
+      </div>
+
+      <div className="px-3 py-3 flex flex-col gap-2">
+        <div className="grid grid-cols-2 gap-2">
+          <select
+            value={params.retuneScale}
+            onChange={(e) => updateParams({ retuneScale: e.target.value as EngineParams['retuneScale'] })}
+            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
           >
-            Custom
-          </button>
+            {SCALE_OPTIONS.map((scale) => (
+              <option key={scale} value={scale}>{scale.replace('_', ' ')}</option>
+            ))}
+          </select>
+
+          <select
+            value={params.retuneKey}
+            onChange={(e) => updateParams({ retuneKey: Number(e.target.value) })}
+            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
+          >
+            {NOTE_NAMES.map((note, index) => (
+              <option key={note} value={index}>{note}</option>
+            ))}
+          </select>
         </div>
+
+        <select
+          value={quantizeMode}
+          onChange={(e) => {
+            const mode = e.target.value as (typeof QUANTIZE_MODES)[number];
+            if (mode === 'preserve attacks') {
+              updateParams({ retunePreserveTransients: true, retuneOutOfMaskMode: 'nearest' });
+            } else if (mode === 'glide') {
+              updateParams({ retunePreserveTransients: false, retuneOutOfMaskMode: 'preserve' });
+            } else {
+              updateParams({ retunePreserveTransients: false, retuneOutOfMaskMode: 'nearest' });
+            }
+          }}
+          className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
+        >
+          {QUANTIZE_MODES.map((mode) => (
+            <option key={mode} value={mode}>{mode}</option>
+          ))}
+        </select>
       </div>
 
-      {params.retuneUseCustomMask ? (
-        <div className="rounded-lg border border-border bg-surface-2/60 p-3">
-          <div className="flex items-center justify-between gap-2">
-            <div className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Target Mask</div>
-            <button
-              onClick={() => updateParams({ retuneTargetMask: buildScaleMask(params.retuneKey, params.retuneScale) })}
-              className="rounded border border-border px-2 py-1 text-[10px] uppercase tracking-wide text-text-secondary transition-colors hover:border-text-dim hover:text-text-primary"
-            >
-              Reset To Scale
-            </button>
-          </div>
-          <div className="mt-3 grid grid-cols-6 gap-2">
-            {NOTE_NAMES.map((noteName, pitchClass) => {
-              const active = Boolean(targetMask[pitchClass]);
-              const isKeyRoot = pitchClass === params.retuneKey;
-              return (
-                <button
-                  key={noteName}
-                  onClick={() => handleMaskToggle(pitchClass)}
-                  className="rounded-md border px-2 py-2 text-xs font-medium transition-colors"
-                  style={{
-                    background: active ? `${color}22` : '#14142b',
-                    borderColor: active ? `${color}66` : '#3a3a5c',
-                    color: active ? '#e8e8f0' : '#8888a8',
-                    boxShadow: isKeyRoot ? `inset 0 0 0 1px ${color}` : 'none',
-                  }}
-                >
-                  {noteName}
-                </button>
-              );
-            })}
-          </div>
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <span className="text-[10px] uppercase tracking-[0.24em] text-text-dim">Out of Mask</span>
-            {OUT_OF_MASK_MODES.map((mode) => {
-              const active = params.retuneOutOfMaskMode === mode;
-              return (
-                <button
-                  key={mode}
-                  onClick={() => updateParams({ retuneOutOfMaskMode: mode })}
-                  className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
-                  style={{
-                    background: active ? `${color}22` : '#14142b',
-                    borderColor: active ? `${color}66` : '#3a3a5c',
-                    color: active ? '#e8e8f0' : '#8888a8',
-                  }}
-                >
-                  {mode}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ) : (
-        <div className="rounded-lg border border-border bg-surface-2/60 px-3 py-2.5 text-[11px] text-text-secondary">
-          Targets follow <span className="text-text-primary">{NOTE_NAMES[Math.round(params.retuneKey)]} {formatScaleLabel(params.retuneScale)}</span> automatically.
-        </div>
-      )}
-
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          onClick={() => updateParams({ retunePreserveTransients: !params.retunePreserveTransients })}
-          className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
-          style={{
-            background: params.retunePreserveTransients ? `${color}22` : '#14142b',
-            borderColor: params.retunePreserveTransients ? `${color}66` : '#3a3a5c',
-            color: params.retunePreserveTransients ? '#e8e8f0' : '#8888a8',
-          }}
-        >
-          Preserve Attacks
-        </button>
-        <button
-          onClick={() => updateParams({ retuneCollapseDuplicates: !params.retuneCollapseDuplicates })}
-          className="rounded-md border px-2.5 py-1.5 text-[11px] uppercase tracking-wide transition-colors"
-          style={{
-            background: params.retuneCollapseDuplicates ? `${color}22` : '#14142b',
-            borderColor: params.retuneCollapseDuplicates ? `${color}66` : '#3a3a5c',
-            color: params.retuneCollapseDuplicates ? '#e8e8f0' : '#8888a8',
-          }}
-        >
-          Collapse Duplicates
-        </button>
-      </div>
-
-      <div className="flex flex-wrap items-end justify-center gap-4">
+      <div className="grid grid-cols-2 gap-3 px-3 pb-3">
         <Knob
-          label="Strength"
+          label="Speed"
           value={params.retuneStrength}
           onChange={(value) => updateParams({ retuneStrength: value })}
           color={color}
           displayValue={`${Math.round(params.retuneStrength * 100)}%`}
         />
         <Knob
-          label="Deadband"
-          value={params.retuneDeadbandCents}
-          onChange={(value) => updateParams({ retuneDeadbandCents: value })}
-          color={color}
-          min={0}
-          max={40}
-          displayValue={`${Math.round(params.retuneDeadbandCents)} cents`}
-        />
-        <Knob
-          label="Gate"
-          value={params.retuneConfidenceGate}
-          onChange={(value) => updateParams({ retuneConfidenceGate: value })}
-          color={color}
-          min={0}
-          max={0.6}
-          displayValue={`${Math.round(params.retuneConfidenceGate * 100)}%`}
-        />
-        <Knob
-          label="Texture"
+          label="Strength"
           value={params.retuneTextureAmount}
           onChange={(value) => updateParams({ retuneTextureAmount: value })}
           color={color}
           displayValue={`${Math.round(params.retuneTextureAmount * 100)}%`}
         />
         <Knob
-          label="Low Blend"
-          value={params.retuneLowEndBlend}
-          onChange={(value) => updateParams({ retuneLowEndBlend: value })}
-          color={color}
-          displayValue={`${Math.round(params.retuneLowEndBlend * 100)}%`}
-        />
-        <Knob
-          label="Air"
+          label="Octave"
           value={params.retuneAirMix}
           onChange={(value) => updateParams({ retuneAirMix: value })}
           color={color}
           min={0}
           max={1.5}
-          displayValue={`${Math.round(params.retuneAirMix * 100)}%`}
+          displayValue={params.retuneAirMix.toFixed(2)}
+        />
+        <Knob
+          label="Level"
+          value={params.retuneLowEndBlend}
+          onChange={(value) => updateParams({ retuneLowEndBlend: value })}
+          color={color}
+          displayValue={`${Math.round(params.retuneLowEndBlend * 100)}%`}
         />
       </div>
-    </EffectModule>
+    </div>
   );
 }

--- a/ui/src/components/SpectrumAnalyzer.tsx
+++ b/ui/src/components/SpectrumAnalyzer.tsx
@@ -149,7 +149,7 @@ export function SpectrumAnalyzer({
       ctx.fillText(String(gain), 28, gainToY(gain, height) - 4);
     });
 
-    const meterX = width - 22;
+    const meterX = width - 38;
     const meterY = 16;
     const meterW = 8;
     const meterH = height - 32;
@@ -159,6 +159,10 @@ export function SpectrumAnalyzer({
     ctx.strokeStyle = '#344062';
     ctx.strokeRect(meterX, meterY, meterW, meterH);
     ctx.strokeRect(meterX + 10, meterY, meterW, meterH);
+    ctx.fillStyle = '#e4e8f5';
+    ctx.font = '10px Inter, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.fillText('OUTPUT', meterX - 2, 12);
 
     let level = 0.35;
     if (analyser) {
@@ -176,6 +180,14 @@ export function SpectrumAnalyzer({
     ctx.fillStyle = grad;
     ctx.fillRect(meterX, meterY + meterH - fillH, meterW, fillH);
     ctx.fillRect(meterX + 10, meterY + meterH - fillH * 0.95, meterW, fillH * 0.95);
+
+    ctx.textAlign = 'left';
+    ctx.fillStyle = '#7f89ac';
+    const meterTicks = [0, -6, -12, -18, -24, -36, -48, -60];
+    meterTicks.forEach((tick) => {
+      const y = meterY + ((-tick) / 60) * meterH;
+      ctx.fillText(String(tick), meterX + 22, y + 3);
+    });
   }, [analyser, eqBands, height, retuneBandColor, retuneBandEndHz, retuneBandStartHz, width]);
 
   useEffect(() => {

--- a/ui/src/components/SpectrumAnalyzer.tsx
+++ b/ui/src/components/SpectrumAnalyzer.tsx
@@ -1,30 +1,21 @@
-import { useRef, useEffect, useCallback, useState } from 'react';
-import type { EQBand, RetuneStatus } from '../audio/engine';
-import { formatMidiNote, midiToFreq, NOTE_NAMES } from '../audio/retune';
+import { useRef, useEffect, useCallback } from 'react';
+import type { EQBand } from '../audio/engine';
 
 interface SpectrumAnalyzerProps {
   analyser: AnalyserNode | null;
   eqBands: EQBand[];
-  retuneStatus: RetuneStatus | null;
-  retuneEnabled: boolean;
-  retuneKey: number;
-  retuneScale: string;
   onBandChange: (index: number, band: Partial<EQBand>) => void;
   width: number;
   height: number;
+  retuneBandStartHz: number;
+  retuneBandEndHz: number;
+  retuneBandColor: string;
 }
 
-// Frequency label positions
-const FREQ_LABELS = [20, 50, 100, 200, 500, '1k', '2k', '5k', '10k', '20k'];
 const FREQ_VALUES = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000];
-
-// Band colors matching the effect module accents
-const BAND_COLORS = ['#c45e3e', '#4a6fa5', '#4ec48a', '#8a5ec4', '#3eafc4'];
-const RETUNE_STATE_COLORS = {
-  mapped: '#4ec48a',
-  preserved: '#8b90ad',
-  muted: '#d96b6b',
-} as const;
+const FREQ_LABELS = ['20', '50', '100', '200', '500', '1k', '2k', '5k', '10k', '20k'];
+const GAIN_VALUES = [24, 12, 0, -12, -24];
+const BAND_COLORS = ['#2d5f9f', '#3b73bb', '#4891ff', '#58a5f8', '#72bcff'];
 
 function freqToX(freq: number, width: number): number {
   const minLog = Math.log10(20);
@@ -40,7 +31,6 @@ function xToFreq(x: number, width: number): number {
 }
 
 function gainToY(gain: number, height: number): number {
-  // Map -24dB to +24dB to canvas height
   return height / 2 - (gain / 24) * (height / 2);
 }
 
@@ -48,407 +38,185 @@ function yToGain(y: number, height: number): number {
   return -((y - height / 2) / (height / 2)) * 24;
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
-function drawRoundedRect(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  radius: number,
-) {
-  ctx.beginPath();
-  ctx.moveTo(x + radius, y);
-  ctx.lineTo(x + width - radius, y);
-  ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
-  ctx.lineTo(x + width, y + height - radius);
-  ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
-  ctx.lineTo(x + radius, y + height);
-  ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
-  ctx.lineTo(x, y + radius);
-  ctx.quadraticCurveTo(x, y, x + radius, y);
-  ctx.closePath();
-}
-
-function formatKeyLabel(key: number): string {
-  return NOTE_NAMES[((Math.round(key) % 12) + 12) % 12];
-}
-
-/** Compute approximate EQ response contribution for a single band at a given frequency */
-function bandResponse(band: EQBand, freq: number): number {
-  const bandType = band.type || 'peak';
-  const octaves = Math.log2(freq / band.freq);
-
-  switch (bandType) {
-    case 'peak': {
-      if (band.gain === 0) return 0;
-      return band.gain * Math.exp(-0.5 * Math.pow(octaves * band.q * 1.5, 2));
-    }
-    case 'lowshelf': {
-      if (band.gain === 0) return 0;
-      // Sigmoid transition: full gain below, zero above
-      const t = 1 / (1 + Math.exp(octaves * band.q * 3));
-      return band.gain * t;
-    }
-    case 'highshelf': {
-      if (band.gain === 0) return 0;
-      // Sigmoid transition: zero below, full gain above
-      const t = 1 / (1 + Math.exp(-octaves * band.q * 3));
-      return band.gain * t;
-    }
-    case 'lowpass': {
-      // Show rolloff above cutoff
-      if (octaves > 0) return -octaves * band.q * 12;
-      return 0;
-    }
-    case 'highpass': {
-      // Show rolloff below cutoff
-      if (octaves < 0) return Math.abs(octaves) * band.q * -12;
-      return 0;
-    }
-    default:
-      return 0;
-  }
-}
-
 export function SpectrumAnalyzer({
   analyser,
   eqBands,
-  retuneStatus,
-  retuneEnabled,
-  retuneKey,
-  retuneScale,
   onBandChange,
   width,
   height,
+  retuneBandStartHz,
+  retuneBandEndHz,
+  retuneBandColor,
 }: SpectrumAnalyzerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animRef = useRef<number>(0);
-  const draggingBand = useRef<number | null>(null);
-  const hoverBand = useRef<number | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
+  const dragIndex = useRef<number | null>(null);
 
   const drawFrame = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext('2d')!;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
     const dpr = window.devicePixelRatio || 1;
     canvas.width = width * dpr;
     canvas.height = height * dpr;
     ctx.scale(dpr, dpr);
     ctx.clearRect(0, 0, width, height);
 
-    // --- Grid ---
-    ctx.strokeStyle = '#1e1e3a';
-    ctx.lineWidth = 1;
+    ctx.fillStyle = '#101126';
+    ctx.fillRect(0, 0, width, height);
 
-    // Frequency grid lines
     for (const freq of FREQ_VALUES) {
       const x = freqToX(freq, width);
       ctx.beginPath();
+      ctx.strokeStyle = '#1f2440';
       ctx.moveTo(x, 0);
       ctx.lineTo(x, height);
       ctx.stroke();
     }
 
-    // Gain grid lines (-24, -12, 0, +12, +24)
-    for (const gain of [-24, -12, 0, 12, 24]) {
+    for (const gain of GAIN_VALUES) {
       const y = gainToY(gain, height);
       ctx.beginPath();
+      ctx.strokeStyle = gain === 0 ? '#394369' : '#1f2440';
       ctx.moveTo(0, y);
       ctx.lineTo(width, y);
-      if (gain === 0) {
-        ctx.strokeStyle = '#3a3a5c';
-      } else {
-        ctx.strokeStyle = '#1e1e3a';
-      }
       ctx.stroke();
     }
 
-    // --- Spectrum data ---
+    const bandStartX = freqToX(retuneBandStartHz, width);
+    const bandEndX = freqToX(retuneBandEndHz, width);
+    ctx.fillStyle = 'rgba(72, 145, 255, 0.16)';
+    ctx.fillRect(bandStartX, 0, bandEndX - bandStartX, height);
+    ctx.strokeStyle = retuneBandColor;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(bandStartX, 0, bandEndX - bandStartX, height);
+
+    for (const x of [bandStartX, bandEndX]) {
+      ctx.fillStyle = '#4891ff';
+      ctx.fillRect(x - 2, 8, 4, height - 16);
+      ctx.fillStyle = '#b8d1ff';
+      ctx.fillRect(x - 4, height / 2 - 14, 8, 28);
+    }
+
+    ctx.fillStyle = '#c8d6ff';
+    ctx.font = '11px Inter, sans-serif';
+    ctx.fillText('RETUNE BAND', bandStartX + 10, 20);
+    ctx.fillText('200 Hz – 5.00 kHz', bandStartX + 10, 36);
+
     if (analyser) {
-      const bufferLength = analyser.frequencyBinCount;
-      const dataArray = new Float32Array(bufferLength);
+      const dataArray = new Float32Array(analyser.frequencyBinCount);
       analyser.getFloatFrequencyData(dataArray);
       const nyquist = analyser.context.sampleRate / 2;
 
-      // Draw spectrum fill
       ctx.beginPath();
-      ctx.moveTo(0, height);
-
-      for (let i = 1; i < bufferLength; i++) {
-        const freq = (i / bufferLength) * nyquist;
-        if (freq < 20 || freq > 20000) continue;
-        const x = freqToX(freq, width);
-        // Map dB range (-100 to 0) to canvas
-        const db = Math.max(-100, Math.min(0, dataArray[i]));
-        const y = height - ((db + 100) / 100) * height * 0.85;
-        if (i === 1 || freq <= 20) {
-          ctx.moveTo(x, y);
-        } else {
-          ctx.lineTo(x, y);
-        }
-      }
-
-      ctx.lineTo(width, height);
-      ctx.closePath();
-
-      // Gradient fill
-      const gradient = ctx.createLinearGradient(0, 0, 0, height);
-      gradient.addColorStop(0, 'rgba(78, 196, 138, 0.3)');
-      gradient.addColorStop(0.5, 'rgba(62, 175, 196, 0.15)');
-      gradient.addColorStop(1, 'rgba(62, 175, 196, 0.02)');
-      ctx.fillStyle = gradient;
-      ctx.fill();
-
-      // Spectrum line
-      ctx.beginPath();
-      for (let i = 1; i < bufferLength; i++) {
-        const freq = (i / bufferLength) * nyquist;
+      for (let i = 1; i < dataArray.length; i++) {
+        const freq = (i / dataArray.length) * nyquist;
         if (freq < 20 || freq > 20000) continue;
         const x = freqToX(freq, width);
         const db = Math.max(-100, Math.min(0, dataArray[i]));
-        const y = height - ((db + 100) / 100) * height * 0.85;
-        if (i === 1 || freq <= 20) {
-          ctx.moveTo(x, y);
-        } else {
-          ctx.lineTo(x, y);
-        }
+        const y = height - ((db + 100) / 100) * height * 0.82;
+        if (i === 1) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
       }
-      ctx.strokeStyle = 'rgba(78, 196, 138, 0.6)';
+      ctx.strokeStyle = '#56c5ce';
       ctx.lineWidth = 1.5;
       ctx.stroke();
     }
 
-    // --- EQ curve ---
-    // Draw approximate combined EQ curve for all filter types
-    ctx.beginPath();
-    let started = false;
-    for (let px = 0; px < width; px += 2) {
-      const freq = xToFreq(px, width);
-      let totalGain = 0;
-      for (let b = 0; b < eqBands.length; b++) {
-        totalGain += bandResponse(eqBands[b], freq);
-      }
-      const y = gainToY(totalGain, height);
-      if (!started) {
-        ctx.moveTo(px, y);
-        started = true;
-      } else {
-        ctx.lineTo(px, y);
-      }
-    }
-    ctx.strokeStyle = 'rgba(232, 232, 240, 0.5)';
-    ctx.lineWidth = 2;
-    ctx.stroke();
-
-    // Fill under EQ curve
-    ctx.lineTo(width, height / 2);
-    ctx.lineTo(0, height / 2);
-    ctx.closePath();
-    ctx.fillStyle = 'rgba(232, 232, 240, 0.04)';
-    ctx.fill();
-
-    // --- EQ Band nodes ---
     for (let i = 0; i < eqBands.length; i++) {
-      const band = eqBands[i];
-      const x = freqToX(band.freq, width);
-      const y = gainToY(band.gain, height);
-      const isHovered = hoverBand.current === i;
-      const isDragging = draggingBand.current === i;
-      const nodeSize = isHovered || isDragging ? 8 : 6;
-
-      // Glow
-      if (isHovered || isDragging) {
-        ctx.beginPath();
-        ctx.arc(x, y, 16, 0, 2 * Math.PI);
-        ctx.fillStyle = BAND_COLORS[i] + '20';
-        ctx.fill();
-      }
-
-      // Node outline
+      const x = freqToX(eqBands[i].freq, width);
+      const y = gainToY(eqBands[i].gain, height);
       ctx.beginPath();
-      ctx.arc(x, y, nodeSize, 0, 2 * Math.PI);
+      ctx.arc(x, y, 6, 0, Math.PI * 2);
       ctx.fillStyle = '#0d0d1a';
       ctx.fill();
-      ctx.strokeStyle = BAND_COLORS[i];
+      ctx.strokeStyle = BAND_COLORS[i % BAND_COLORS.length];
       ctx.lineWidth = 2;
       ctx.stroke();
-
-      // Node fill
-      ctx.beginPath();
-      ctx.arc(x, y, nodeSize - 2, 0, 2 * Math.PI);
-      ctx.fillStyle = isDragging ? BAND_COLORS[i] : '#14142b';
-      ctx.fill();
     }
 
-    // --- Frequency labels ---
-    ctx.fillStyle = '#555570';
+    ctx.fillStyle = '#66709a';
     ctx.font = '10px Inter, sans-serif';
     ctx.textAlign = 'center';
-    for (let i = 0; i < FREQ_LABELS.length; i++) {
-      const x = freqToX(FREQ_VALUES[i], width);
-      ctx.fillText(String(FREQ_LABELS[i]), x, height - 4);
+    FREQ_VALUES.forEach((f, i) => {
+      ctx.fillText(FREQ_LABELS[i], freqToX(f, width), height - 6);
+    });
+
+    ctx.textAlign = 'right';
+    GAIN_VALUES.forEach((gain) => {
+      ctx.fillText(String(gain), 28, gainToY(gain, height) - 4);
+    });
+
+    const meterX = width - 22;
+    const meterY = 16;
+    const meterW = 8;
+    const meterH = height - 32;
+    ctx.fillStyle = '#141a2e';
+    ctx.fillRect(meterX, meterY, meterW, meterH);
+    ctx.fillRect(meterX + 10, meterY, meterW, meterH);
+    ctx.strokeStyle = '#344062';
+    ctx.strokeRect(meterX, meterY, meterW, meterH);
+    ctx.strokeRect(meterX + 10, meterY, meterW, meterH);
+
+    let level = 0.35;
+    if (analyser) {
+      const td = new Float32Array(analyser.fftSize);
+      analyser.getFloatTimeDomainData(td);
+      let peak = 0;
+      for (let i = 0; i < td.length; i++) peak = Math.max(peak, Math.abs(td[i]));
+      level = Math.min(1, peak * 2.2);
     }
-
-    if (retuneEnabled) {
-      const overlayNotes = [...(retuneStatus?.notes ?? [])]
-        .sort((a, b) => b.energy - a.energy)
-        .slice(0, 4);
-      const overlayHeight = 42 + overlayNotes.length * 18;
-      const overlayWidth = width - 24;
-
-      ctx.save();
-      drawRoundedRect(ctx, 12, 12, overlayWidth, overlayHeight, 12);
-      const overlayGradient = ctx.createLinearGradient(12, 12, 12, 12 + overlayHeight);
-      overlayGradient.addColorStop(0, 'rgba(13, 13, 26, 0.9)');
-      overlayGradient.addColorStop(1, 'rgba(20, 20, 43, 0.76)');
-      ctx.fillStyle = overlayGradient;
-      ctx.fill();
-      ctx.strokeStyle = 'rgba(78, 196, 138, 0.22)';
-      ctx.lineWidth = 1;
-      ctx.stroke();
-
-      ctx.textAlign = 'left';
-      ctx.font = '11px Inter, sans-serif';
-      ctx.fillStyle = '#e8e8f0';
-      const stateLabel = !retuneStatus
-        ? 'Waiting'
-        : retuneStatus.overloaded
-          ? 'Overloaded'
-          : retuneStatus.noteCount > 0
-            ? 'Tracking'
-            : 'Listening';
-      ctx.fillText(`RETUNE ${formatKeyLabel(retuneKey)} ${retuneScale.replace('_', ' ')} · ${stateLabel}`, 24, 31);
-
-      ctx.font = '10px Inter, sans-serif';
-      ctx.fillStyle = '#8888a8';
-      const meta = [
-        `${retuneStatus?.noteCount ?? 0} groups`,
-        retuneStatus ? `${Math.round(retuneStatus.confidence * 100)}% conf` : 'no lock',
-        retuneStatus?.lowEndLocked ? 'low locked' : 'low floating',
-      ];
-      if (retuneStatus?.transientBypassActive) {
-        meta.push('attack hold');
-      }
-      ctx.fillText(meta.join(' · '), 24, 47);
-
-      overlayNotes.forEach((note, index) => {
-        const sourceX = clamp(freqToX(midiToFreq(note.sourceMidi), width), 90, width - 24);
-        const targetX = clamp(freqToX(midiToFreq(note.targetMidi), width), 90, width - 24);
-        const y = 67 + index * 18;
-        const color = RETUNE_STATE_COLORS[note.state];
-        const label = note.state === 'mapped'
-          ? `${formatMidiNote(note.sourceMidi)} → ${formatMidiNote(note.targetMidi)}`
-          : `${formatMidiNote(note.sourceMidi)} ${note.state}`;
-
-        ctx.strokeStyle = `${color}cc`;
-        ctx.lineWidth = note.isLowEnd ? 2.2 : 1.4;
-        ctx.beginPath();
-        ctx.moveTo(sourceX, y);
-        ctx.lineTo(targetX, y);
-        ctx.stroke();
-
-        ctx.fillStyle = '#0d0d1a';
-        ctx.beginPath();
-        ctx.arc(sourceX, y, 3.5, 0, 2 * Math.PI);
-        ctx.fill();
-        ctx.stroke();
-
-        ctx.beginPath();
-        ctx.arc(targetX, y, 4.5, 0, 2 * Math.PI);
-        ctx.fill();
-        ctx.stroke();
-
-        const chipText = note.isLowEnd ? `${label} · LOW` : label;
-        ctx.font = '10px Inter, sans-serif';
-        const chipWidth = ctx.measureText(chipText).width + 14;
-        const chipX = clamp((sourceX + targetX) / 2 - chipWidth / 2, 96, width - chipWidth - 18);
-        drawRoundedRect(ctx, chipX, y - 10, chipWidth, 16, 8);
-        ctx.fillStyle = 'rgba(20, 20, 43, 0.94)';
-        ctx.fill();
-        ctx.strokeStyle = `${color}55`;
-        ctx.lineWidth = 1;
-        ctx.stroke();
-        ctx.fillStyle = note.state === 'muted' ? '#f3b2b2' : '#d7d9e5';
-        ctx.fillText(chipText, chipX + 7, y + 4);
-      });
-      ctx.restore();
-    }
-  }, [analyser, eqBands, retuneEnabled, retuneKey, retuneScale, retuneStatus, width, height]);
+    const fillH = meterH * level;
+    const grad = ctx.createLinearGradient(0, meterY + meterH, 0, meterY);
+    grad.addColorStop(0, '#2bc6cf');
+    grad.addColorStop(0.7, '#8bde8f');
+    grad.addColorStop(1, '#f4d36f');
+    ctx.fillStyle = grad;
+    ctx.fillRect(meterX, meterY + meterH - fillH, meterW, fillH);
+    ctx.fillRect(meterX + 10, meterY + meterH - fillH * 0.95, meterW, fillH * 0.95);
+  }, [analyser, eqBands, height, retuneBandColor, retuneBandEndHz, retuneBandStartHz, width]);
 
   useEffect(() => {
     const render = () => {
       drawFrame();
       animRef.current = requestAnimationFrame(render);
     };
-
     animRef.current = requestAnimationFrame(render);
     return () => cancelAnimationFrame(animRef.current);
   }, [drawFrame]);
 
-  // Hit testing for band nodes
-  const findBandAt = useCallback((clientX: number, clientY: number): number | null => {
-    const canvas = canvasRef.current;
-    if (!canvas) return null;
-    const rect = canvas.getBoundingClientRect();
-    const x = clientX - rect.left;
-    const y = clientY - rect.top;
-
+  const findBand = useCallback((x: number, y: number) => {
     for (let i = 0; i < eqBands.length; i++) {
       const bx = freqToX(eqBands[i].freq, width);
       const by = gainToY(eqBands[i].gain, height);
-      const dist = Math.sqrt((x - bx) ** 2 + (y - by) ** 2);
-      if (dist < 16) return i;
+      if (Math.hypot(bx - x, by - y) < 15) return i;
     }
     return null;
-  }, [eqBands, width, height]);
-
-  const onPointerDown = useCallback((e: React.PointerEvent) => {
-    const idx = findBandAt(e.clientX, e.clientY);
-    if (idx !== null) {
-      draggingBand.current = idx;
-      setIsDragging(true);
-      (e.target as HTMLElement).setPointerCapture(e.pointerId);
-    }
-  }, [findBandAt]);
-
-  const onPointerMove = useCallback((e: React.PointerEvent) => {
-    if (draggingBand.current !== null) {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const rect = canvas.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      const freq = Math.max(20, Math.min(20000, xToFreq(x, width)));
-      const gain = Math.max(-24, Math.min(24, yToGain(y, height)));
-      onBandChange(draggingBand.current, { freq, gain });
-    } else {
-      hoverBand.current = findBandAt(e.clientX, e.clientY);
-    }
-  }, [findBandAt, onBandChange, width, height]);
-
-  const onPointerUp = useCallback(() => {
-    draggingBand.current = null;
-    setIsDragging(false);
-  }, []);
+  }, [eqBands, height, width]);
 
   return (
     <canvas
       ref={canvasRef}
-      style={{ width, height, cursor: isDragging ? 'grabbing' : 'crosshair' }}
-      className="block rounded-lg"
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerLeave={() => {
-        hoverBand.current = null;
-        draggingBand.current = null;
-        setIsDragging(false);
+      style={{ width, height, cursor: 'crosshair' }}
+      className="block rounded-lg border border-border"
+      onPointerDown={(e) => {
+        const rect = (e.target as HTMLElement).getBoundingClientRect();
+        dragIndex.current = findBand(e.clientX - rect.left, e.clientY - rect.top);
       }}
+      onPointerMove={(e) => {
+        if (dragIndex.current === null) return;
+        const rect = (e.target as HTMLElement).getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        onBandChange(dragIndex.current, {
+          freq: Math.max(20, Math.min(20000, xToFreq(x, width))),
+          gain: Math.max(-24, Math.min(24, yToGain(y, height))),
+        });
+      }}
+      onPointerUp={() => { dragIndex.current = null; }}
+      onPointerLeave={() => { dragIndex.current = null; }}
     />
   );
 }

--- a/ui/src/components/Toolbar.tsx
+++ b/ui/src/components/Toolbar.tsx
@@ -6,15 +6,6 @@ interface ToolbarProps {
   isPlaying: boolean;
   onTogglePlay: () => void;
   onStop: () => void;
-  currentTime: number;
-  duration: number;
-  onSeek: (t: number) => void;
-}
-
-function formatTime(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
-  return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
 export function Toolbar({
@@ -25,95 +16,65 @@ export function Toolbar({
   isPlaying,
   onTogglePlay,
   onStop,
-  currentTime,
-  duration,
-  onSeek,
 }: ToolbarProps) {
   return (
-    <div className="flex items-center gap-3 px-4 py-2 bg-surface-1 border-b border-border">
-      {/* Logo */}
+    <div className="flex items-center gap-2 px-3 py-2 bg-surface-1 border-b border-border">
       <div className="flex items-center gap-2 mr-2">
-        <div className="w-6 h-6 rounded bg-accent-retune/20 flex items-center justify-center">
-          <span className="text-accent-retune text-xs font-bold">Q</span>
+        <div className="w-5 h-5 rounded bg-accent-retune/20 flex items-center justify-center">
+          <span className="text-accent-retune text-[10px] font-bold">Q</span>
         </div>
-        <span className="text-sm font-semibold tracking-wide text-text-primary">
+        <span className="text-xs font-semibold tracking-[0.16em] text-text-primary">
           QUANTUM DISTORTION
         </span>
       </div>
 
-      {/* Separator */}
-      <div className="w-px h-6 bg-border" />
+      <div className="w-px h-5 bg-border" />
 
-      {/* Bypass */}
+      <button className="px-2 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-secondary hover:text-text-primary">◀</button>
+      <select className="px-2 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-primary min-w-36">
+        <option>Default Preset</option>
+        <option>Modern Bass Tight</option>
+        <option>Wide Harmonics</option>
+      </select>
+      <button className="px-2 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-secondary hover:text-text-primary">▶</button>
+
       <button
         onClick={onBypassToggle}
-        className={`px-3 py-1 text-xs rounded font-medium transition-colors ${
+        className={`px-2.5 py-1 text-[10px] rounded font-medium border ${
           bypass
-            ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/40'
-            : 'bg-surface-2 text-text-secondary border border-border hover:text-text-primary'
+            ? 'bg-yellow-500/20 text-yellow-400 border-yellow-500/40'
+            : 'bg-surface-2 text-text-secondary border-border hover:text-text-primary'
         }`}
       >
-        Bypass
+        BYPASS
       </button>
+      <button className="px-2 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-secondary">A/B</button>
+      <button className="px-2 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-secondary">UNDO</button>
+      <button className="px-2 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-secondary">REDO</button>
+      <button className="px-2 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-secondary">SET</button>
 
-      {/* Separator */}
-      <div className="w-px h-6 bg-border" />
+      <div className="flex-1" />
 
-      {/* File / Transport */}
       <button
         onClick={onOpenFile}
-        className="px-3 py-1 text-xs rounded bg-surface-2 text-text-secondary border border-border hover:text-text-primary hover:border-text-dim transition-colors"
+        className="px-2.5 py-1 text-[10px] rounded bg-surface-2 border border-border text-text-secondary hover:text-text-primary"
       >
-        {fileName ?? 'Open File'}
+        {fileName ?? 'OPEN'}
       </button>
-
       <button
         onClick={onTogglePlay}
         disabled={!fileName}
-        className="w-7 h-7 rounded-full bg-surface-2 border border-border flex items-center justify-center hover:border-text-dim disabled:opacity-30 transition-colors"
+        className="w-7 h-7 rounded-full bg-surface-2 border border-border flex items-center justify-center disabled:opacity-30"
       >
-        {isPlaying ? (
-          <span className="text-text-primary text-[10px]">&#9646;&#9646;</span>
-        ) : (
-          <span className="text-text-primary text-xs ml-0.5">&#9654;</span>
-        )}
+        <span className="text-text-primary text-[10px]">{isPlaying ? '❚❚' : '▶'}</span>
       </button>
-
       <button
         onClick={onStop}
         disabled={!fileName}
-        className="w-7 h-7 rounded-full bg-surface-2 border border-border flex items-center justify-center hover:border-text-dim disabled:opacity-30 transition-colors"
+        className="w-7 h-7 rounded-full bg-surface-2 border border-border flex items-center justify-center disabled:opacity-30"
       >
-        <span className="text-text-primary text-[10px]">&#9632;</span>
+        <span className="text-text-primary text-[10px]">■</span>
       </button>
-
-      {/* Time display */}
-      {duration > 0 && (
-        <div className="flex items-center gap-2">
-          <span className="text-xs tabular-nums text-text-secondary">
-            {formatTime(currentTime)} / {formatTime(duration)}
-          </span>
-          <input
-            type="range"
-            min={0}
-            max={duration}
-            step={0.01}
-            value={currentTime}
-            onChange={(e) => onSeek(parseFloat(e.target.value))}
-            className="w-32"
-          />
-        </div>
-      )}
-
-      {/* Spacer */}
-      <div className="flex-1" />
-
-      {/* Keyboard shortcuts hint */}
-      <div className="flex items-center gap-2">
-        <span className="text-[10px] text-text-dim tracking-wide">
-          SPACE play/pause · R restart
-        </span>
-      </div>
     </div>
   );
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -11,7 +11,7 @@
   --color-accent-delay: #3eafc4;
   --color-accent-modulate: #8a5ec4;
   --color-accent-lofi: #8a7e5e;
-  --color-accent-retune: #4ec48a;
+  --color-accent-retune: #4891ff;
   --color-accent-quantize: #4ec48a;
   --color-text-primary: #e8e8f0;
   --color-text-secondary: #8888a8;


### PR DESCRIPTION
### Motivation
- Simplify and modernize the main UI layout by consolidating repeated module chrome into a reusable shell and moving away from a dynamic slot system to a fixed module arrangement.
- Improve usability of the Retune workflow and make the spectrum visualization clearer by surfacing the retune band and meter visuals.
- Expose additional engine parameters for saturation, sub-generator and output limiter so the UI can control new behavior in the audio engine.

### Description
- Reworked `App.tsx` to introduce `ModuleShell`, removed the dynamic FX slot machinery and replaced it with a fixed row of modules (Primary Saturator, Retune, Secondary Saturator, Sub Generator, Output) and updated controls (selects, knobs, toggles).
- Updated `engine.ts` to add new params and defaults: `saturateSoftness`, `saturateMix`, `saturate2Softness`, `saturate2Mix`, `subRootNote`, `subOctave`, `subWaveform`, and `outputLimiterType`, plus small color tweaks in `FX_CATALOG`.
- Simplified and redesigned `RetuneModule.tsx` UI: replaced the previous complex mask UI with compact select/knob controls, added a quantize mode selector and adjusted control labels/layout and minWidth styling.
- Overhauled `SpectrumAnalyzer.tsx`: simplified rendering, updated visual style (background, grid, retune band highlight, meters), removed the old mask/notes overlay and complex EQ curve math, and refined band node drawing and pointer interaction for band dragging.
- Refactored `Toolbar.tsx` to a more compact control bar with preset selector and transport buttons, and reduced/removed the previous time/seek UI.
- Minor theme change in `index.css` to adjust retune accent color.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully.
- Performed a production build with `npm run build`, which completed without errors.
- Started the dev server (`npm start`) and verified the app renders the updated toolbar, spectrum and modules; no runtime exceptions were observed during manual smoke checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f158966c83218f2deea904855b16)