### PR TITLE
Simplify effect module labels and tighten layout

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -45,10 +45,10 @@ function ModuleShell({
         boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.02)',
       }}
     >
-      <div className="flex items-center gap-2 px-3 py-2 border-b" style={{ borderColor: '#23314d' }}>
+      <div className="flex items-center gap-2 px-2.5 py-1.5 border-b" style={{ borderColor: '#23314d' }}>
         {number && (
           <span
-            className="w-[18px] h-[18px] rounded-full text-[10px] font-semibold flex items-center justify-center"
+            className="w-[16px] h-[16px] rounded-full text-[10px] font-semibold flex items-center justify-center"
             style={{ background: `${color}2a`, color }}
           >
             {number}
@@ -62,7 +62,7 @@ function ModuleShell({
           style={{ borderColor: color, background: enabled ? `${color}22` : 'transparent' }}
         />
       </div>
-      <div className="px-3 py-3 flex flex-col gap-2">{children}</div>
+      <div className="px-2 py-2 flex flex-col gap-1.5">{children}</div>
     </div>
   );
 }
@@ -149,29 +149,31 @@ export default function App() {
       <div className="flex gap-2 px-2 py-3 overflow-x-auto items-stretch">
         <ModuleShell
           number="1"
-          title="Primary Saturator"
+          title="Saturator"
           color="#d88b52"
           enabled={params.saturateEnabled}
           onToggle={() => updateParams({ saturateEnabled: !params.saturateEnabled })}
-          minWidth={190}
+          minWidth={220}
         >
-          <select
-            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
-            value={params.saturateType === 'wavefold' ? 'Foldback' : params.saturateType === 'tube' ? 'Tube' : 'Analog Tape'}
-            onChange={(e) => {
-              const val = e.target.value;
-              updateParams({ saturateType: val === 'Tube' ? 'tube' : val === 'Foldback' ? 'wavefold' : 'tape' });
-            }}
-          >
-            {SAT_TYPES.map((type) => <option key={type}>{type}</option>)}
-          </select>
-          <select value={params.saturateSoftness} onChange={(e) => updateParams({ saturateSoftness: e.target.value as 'soft' | 'medium' | 'hard' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
-            {SOFTNESS.map((softness) => <option key={softness} value={softness.toLowerCase()}>{softness}</option>)}
-          </select>
-          <div className="flex flex-col items-center gap-2">
-            <Knob label="Drive" value={params.saturateDrive} onChange={(v) => updateParams({ saturateDrive: v })} color="#d88b52" displayValue={`${Math.round(params.saturateDrive * 100)}%`} />
-            <Knob label="Tone" value={params.saturateTilt} onChange={(v) => updateParams({ saturateTilt: v })} color="#d88b52" displayValue={`${Math.round((params.saturateTilt - 0.5) * 200)}`} />
-            <Knob label="Mix" value={params.saturateMix} onChange={(v) => updateParams({ saturateMix: v })} color="#d88b52" displayValue={`${Math.round(params.saturateMix * 100)}%`} />
+          <div className="grid grid-cols-2 gap-1.5">
+            <select
+              className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary"
+              value={params.saturateType === 'wavefold' ? 'Foldback' : params.saturateType === 'tube' ? 'Tube' : 'Analog Tape'}
+              onChange={(e) => {
+                const val = e.target.value;
+                updateParams({ saturateType: val === 'Tube' ? 'tube' : val === 'Foldback' ? 'wavefold' : 'tape' });
+              }}
+            >
+              {SAT_TYPES.map((type) => <option key={type}>{type}</option>)}
+            </select>
+            <select value={params.saturateSoftness} onChange={(e) => updateParams({ saturateSoftness: e.target.value as 'soft' | 'medium' | 'hard' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary">
+              {SOFTNESS.map((softness) => <option key={softness} value={softness.toLowerCase()}>{softness}</option>)}
+            </select>
+          </div>
+          <div className="flex justify-around items-end gap-1">
+            <Knob label="Drive" size={48} value={params.saturateDrive} onChange={(v) => updateParams({ saturateDrive: v })} color="#d88b52" displayValue={`${Math.round(params.saturateDrive * 100)}%`} />
+            <Knob label="Tone" size={48} value={params.saturateTilt} onChange={(v) => updateParams({ saturateTilt: v })} color="#d88b52" displayValue={`${Math.round((params.saturateTilt - 0.5) * 200)}`} />
+            <Knob label="Mix" size={48} value={params.saturateMix} onChange={(v) => updateParams({ saturateMix: v })} color="#d88b52" displayValue={`${Math.round(params.saturateMix * 100)}%`} />
           </div>
         </ModuleShell>
 
@@ -179,66 +181,77 @@ export default function App() {
 
         <ModuleShell
           number="3"
-          title="Secondary Saturator"
+          title="Saturator"
           color="#9d6ee9"
           enabled={params.saturate2Enabled}
           onToggle={() => updateParams({ saturate2Enabled: !params.saturate2Enabled })}
-          minWidth={190}
+          minWidth={220}
         >
-          <select
-            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
-            value={params.saturate2Type === 'wavefold' ? 'Foldback' : params.saturate2Type === 'tube' ? 'Tube' : 'Analog Tape'}
-            onChange={(e) => {
-              const val = e.target.value;
-              updateParams({ saturate2Type: val === 'Tube' ? 'tube' : val === 'Foldback' ? 'wavefold' : 'tape' });
-            }}
-          >
-            {SAT_TYPES.map((type) => <option key={type}>{type}</option>)}
-          </select>
-          <select value={params.saturate2Softness} onChange={(e) => updateParams({ saturate2Softness: e.target.value as 'soft' | 'medium' | 'hard' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
-            {SOFTNESS.map((softness) => <option key={softness} value={softness.toLowerCase()}>{softness}</option>)}
-          </select>
-          <div className="flex flex-col items-center gap-2">
-            <Knob label="Drive" value={params.saturate2Drive} onChange={(v) => updateParams({ saturate2Drive: v })} color="#9d6ee9" displayValue={`${Math.round(params.saturate2Drive * 100)}%`} />
-            <Knob label="Tone" value={params.saturate2Tilt} onChange={(v) => updateParams({ saturate2Tilt: v })} color="#9d6ee9" displayValue={`${Math.round((params.saturate2Tilt - 0.5) * 200)}`} />
-            <Knob label="Mix" value={params.saturate2Mix} onChange={(v) => updateParams({ saturate2Mix: v })} color="#9d6ee9" displayValue={`${Math.round(params.saturate2Mix * 100)}%`} />
+          <div className="grid grid-cols-2 gap-1.5">
+            <select
+              className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary"
+              value={params.saturate2Type === 'wavefold' ? 'Foldback' : params.saturate2Type === 'tube' ? 'Tube' : 'Analog Tape'}
+              onChange={(e) => {
+                const val = e.target.value;
+                updateParams({ saturate2Type: val === 'Tube' ? 'tube' : val === 'Foldback' ? 'wavefold' : 'tape' });
+              }}
+            >
+              {SAT_TYPES.map((type) => <option key={type}>{type}</option>)}
+            </select>
+            <select value={params.saturate2Softness} onChange={(e) => updateParams({ saturate2Softness: e.target.value as 'soft' | 'medium' | 'hard' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary">
+              {SOFTNESS.map((softness) => <option key={softness} value={softness.toLowerCase()}>{softness}</option>)}
+            </select>
+          </div>
+          <div className="flex justify-around items-end gap-1">
+            <Knob label="Drive" size={48} value={params.saturate2Drive} onChange={(v) => updateParams({ saturate2Drive: v })} color="#9d6ee9" displayValue={`${Math.round(params.saturate2Drive * 100)}%`} />
+            <Knob label="Tone" size={48} value={params.saturate2Tilt} onChange={(v) => updateParams({ saturate2Tilt: v })} color="#9d6ee9" displayValue={`${Math.round((params.saturate2Tilt - 0.5) * 200)}`} />
+            <Knob label="Mix" size={48} value={params.saturate2Mix} onChange={(v) => updateParams({ saturate2Mix: v })} color="#9d6ee9" displayValue={`${Math.round(params.saturate2Mix * 100)}%`} />
           </div>
         </ModuleShell>
 
         <ModuleShell
-          title="Sub (Unquantized)"
+          title="Sub"
           color="#34c7cf"
           enabled={params.subEnabled}
           onToggle={() => updateParams({ subEnabled: !params.subEnabled })}
           minWidth={220}
         >
-          <select value={params.subRootNote} onChange={(e) => updateParams({ subRootNote: Number(e.target.value) })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
-            {NOTE_OPTIONS.map((note, i) => <option key={note} value={i}>{note}</option>)}
-          </select>
-          <select value={params.subOctave} onChange={(e) => updateParams({ subOctave: Number(e.target.value) as -2 | -1 | 0 })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
-            <option value={-2}>-2</option><option value={-1}>-1</option><option value={0}>0</option>
-          </select>
-          <select value={params.subWaveform} onChange={(e) => updateParams({ subWaveform: e.target.value as 'sine' | 'triangle' | 'rounded_square' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary">
-            <option value="sine">Sine</option><option value="triangle">Triangle</option><option value="rounded_square">Rounded Square</option>
-          </select>
+          <div className="grid grid-cols-3 gap-1.5">
+            <select value={params.subRootNote} onChange={(e) => updateParams({ subRootNote: Number(e.target.value) })} className="text-xs rounded bg-surface-2 border border-border px-1.5 py-1 text-text-primary">
+              {NOTE_OPTIONS.map((note, i) => <option key={note} value={i}>{note}</option>)}
+            </select>
+            <select value={params.subOctave} onChange={(e) => updateParams({ subOctave: Number(e.target.value) as -2 | -1 | 0 })} className="text-xs rounded bg-surface-2 border border-border px-1.5 py-1 text-text-primary">
+              <option value={-2}>-2</option><option value={-1}>-1</option><option value={0}>0</option>
+            </select>
+            <select value={params.subWaveform} onChange={(e) => updateParams({ subWaveform: e.target.value as 'sine' | 'triangle' | 'rounded_square' })} className="text-xs rounded bg-surface-2 border border-border px-1.5 py-1 text-text-primary">
+              <option value="sine">Sine</option><option value="triangle">Tri</option><option value="rounded_square">Sqr</option>
+            </select>
+          </div>
           <div className="flex justify-center">
-            <Knob label="Level" value={params.subLevel} onChange={(v) => updateParams({ subLevel: v })} color="#34c7cf" displayValue={`${Math.round(params.subLevel * 100)}%`} />
+            <Knob label="Level" size={48} value={params.subLevel} onChange={(v) => updateParams({ subLevel: v })} color="#34c7cf" displayValue={`${Math.round(params.subLevel * 100)}%`} />
           </div>
         </ModuleShell>
 
-        <ModuleShell title="Output" color="#3eafc4" enabled={true} onToggle={() => undefined} minWidth={260}>
-          <div className="grid grid-cols-2 gap-2 justify-items-center">
-            <Knob label="Low" value={params.lowGain} onChange={(v) => updateParams({ lowGain: v })} color="#d88b52" min={0} max={2} displayValue={`${(params.lowGain * 100).toFixed(0)}%`} />
-            <Knob label="High" value={params.highGain} onChange={(v) => updateParams({ highGain: v })} color="#4891ff" min={0} max={2} displayValue={`${(params.highGain * 100).toFixed(0)}%`} />
-            <Knob label="Dry/Wet" value={params.dryWet} onChange={(v) => updateParams({ dryWet: v })} color="#3eafc4" displayValue={`${Math.round(params.dryWet * 100)}%`} />
-            <div className="flex flex-col items-center">
-              <Knob label="Gain" value={params.masterGain} onChange={(v) => updateParams({ masterGain: v })} color="#3eafc4" min={0} max={2} size={68} displayValue={`${(params.masterGain * 100).toFixed(0)}%`} />
-            </div>
+        <ModuleShell title="Output" color="#3eafc4" enabled={true} onToggle={() => undefined} minWidth={240}>
+          <div className="grid grid-cols-4 gap-1 justify-items-center">
+            <Knob label="Low" size={48} value={params.lowGain} onChange={(v) => updateParams({ lowGain: v })} color="#d88b52" min={0} max={2} displayValue={`${(params.lowGain * 100).toFixed(0)}%`} />
+            <Knob label="High" size={48} value={params.highGain} onChange={(v) => updateParams({ highGain: v })} color="#4891ff" min={0} max={2} displayValue={`${(params.highGain * 100).toFixed(0)}%`} />
+            <Knob label="Dry/Wet" size={48} value={params.dryWet} onChange={(v) => updateParams({ dryWet: v })} color="#3eafc4" displayValue={`${Math.round(params.dryWet * 100)}%`} />
+            <Knob label="Gain" size={48} value={params.masterGain} onChange={(v) => updateParams({ masterGain: v })} color="#3eafc4" min={0} max={2} displayValue={`${(params.masterGain * 100).toFixed(0)}%`} />
           </div>
-          <select value={params.outputLimiterType} onChange={(e) => updateParams({ outputLimiterType: e.target.value as 'transparent' | 'soft' | 'hard' | 'off' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary mt-1">
+          <select value={params.outputLimiterType} onChange={(e) => updateParams({ outputLimiterType: e.target.value as 'transparent' | 'soft' | 'hard' | 'off' })} className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary">
             <option value="transparent">Transparent</option><option value="soft">Soft</option><option value="hard">Hard</option><option value="off">Off</option>
           </select>
         </ModuleShell>
+
+        <button
+          type="button"
+          className="flex flex-col items-center justify-center rounded-xl border border-dashed flex-shrink-0 text-text-dim hover:text-text-primary hover:border-text-secondary transition-colors"
+          style={{ borderColor: '#23314d', minWidth: 140 }}
+        >
+          <span className="text-lg leading-none mb-1">+</span>
+          <span className="text-[10px] tracking-wider uppercase">Add Effect</span>
+        </button>
       </div>
     </div>
   );

--- a/ui/src/components/RetuneModule.tsx
+++ b/ui/src/components/RetuneModule.tsx
@@ -34,8 +34,8 @@ export function RetuneModule({ color, params, updateParams }: RetuneModuleProps)
         minWidth: 250,
       }}
     >
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-[#4891ff33]">
-        <span className="text-[10px] text-[#9dbfff]">2</span>
+      <div className="flex items-center gap-2 px-2.5 py-1.5 border-b border-[#4891ff33]">
+        <span className="w-[16px] h-[16px] rounded-full text-[10px] font-semibold flex items-center justify-center" style={{ background: `${color}2a`, color: '#9dbfff' }}>2</span>
         <span className="text-xs font-semibold tracking-wider uppercase text-text-primary">Retune</span>
         <div className="flex-1" />
         <button
@@ -46,12 +46,12 @@ export function RetuneModule({ color, params, updateParams }: RetuneModuleProps)
         />
       </div>
 
-      <div className="px-3 py-3 flex flex-col gap-2">
-        <div className="grid grid-cols-2 gap-2">
+      <div className="px-2 py-2 flex flex-col gap-1.5">
+        <div className="grid grid-cols-2 gap-1.5">
           <select
             value={params.retuneScale}
             onChange={(e) => updateParams({ retuneScale: e.target.value as EngineParams['retuneScale'] })}
-            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
+            className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary"
           >
             {SCALE_OPTIONS.map((scale) => (
               <option key={scale} value={scale}>{scale.replace('_', ' ')}</option>
@@ -61,7 +61,7 @@ export function RetuneModule({ color, params, updateParams }: RetuneModuleProps)
           <select
             value={params.retuneKey}
             onChange={(e) => updateParams({ retuneKey: Number(e.target.value) })}
-            className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
+            className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary"
           >
             {NOTE_NAMES.map((note, index) => (
               <option key={note} value={index}>{note}</option>
@@ -81,45 +81,49 @@ export function RetuneModule({ color, params, updateParams }: RetuneModuleProps)
               updateParams({ retunePreserveTransients: false, retuneOutOfMaskMode: 'nearest' });
             }
           }}
-          className="text-xs rounded bg-surface-2 border border-border px-2 py-1.5 text-text-primary"
+          className="text-xs rounded bg-surface-2 border border-border px-2 py-1 text-text-primary"
         >
           {QUANTIZE_MODES.map((mode) => (
             <option key={mode} value={mode}>{mode}</option>
           ))}
         </select>
-      </div>
 
-      <div className="grid grid-cols-2 gap-3 px-3 pb-3">
-        <Knob
-          label="Speed"
-          value={params.retuneStrength}
-          onChange={(value) => updateParams({ retuneStrength: value })}
-          color={color}
-          displayValue={`${Math.round(params.retuneStrength * 100)}%`}
-        />
-        <Knob
-          label="Strength"
-          value={params.retuneTextureAmount}
-          onChange={(value) => updateParams({ retuneTextureAmount: value })}
-          color={color}
-          displayValue={`${Math.round(params.retuneTextureAmount * 100)}%`}
-        />
-        <Knob
-          label="Octave"
-          value={params.retuneAirMix}
-          onChange={(value) => updateParams({ retuneAirMix: value })}
-          color={color}
-          min={0}
-          max={1.5}
-          displayValue={params.retuneAirMix.toFixed(2)}
-        />
-        <Knob
-          label="Level"
-          value={params.retuneLowEndBlend}
-          onChange={(value) => updateParams({ retuneLowEndBlend: value })}
-          color={color}
-          displayValue={`${Math.round(params.retuneLowEndBlend * 100)}%`}
-        />
+        <div className="grid grid-cols-4 gap-1 justify-items-center">
+          <Knob
+            label="Speed"
+            size={48}
+            value={params.retuneStrength}
+            onChange={(value) => updateParams({ retuneStrength: value })}
+            color={color}
+            displayValue={`${Math.round(params.retuneStrength * 100)}%`}
+          />
+          <Knob
+            label="Strength"
+            size={48}
+            value={params.retuneTextureAmount}
+            onChange={(value) => updateParams({ retuneTextureAmount: value })}
+            color={color}
+            displayValue={`${Math.round(params.retuneTextureAmount * 100)}%`}
+          />
+          <Knob
+            label="Octave"
+            size={48}
+            value={params.retuneAirMix}
+            onChange={(value) => updateParams({ retuneAirMix: value })}
+            color={color}
+            min={0}
+            max={1.5}
+            displayValue={params.retuneAirMix.toFixed(2)}
+          />
+          <Knob
+            label="Level"
+            size={48}
+            value={params.retuneLowEndBlend}
+            onChange={(value) => updateParams({ retuneLowEndBlend: value })}
+            color={color}
+            displayValue={`${Math.round(params.retuneLowEndBlend * 100)}%`}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- Rename "Primary Saturator" / "Secondary Saturator" to just "Saturator"
- Rename "Sub (Unquantized)" to "Sub"
- Reduce module padding and stack saturator controls in a horizontal
  row so modules are vertically narrower
- Use 48px knobs across modules for a more compact look
- Add a dashed "Add Effect +" placeholder at the end of the chain